### PR TITLE
Add @LOCALE@ macro for translation

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -878,7 +878,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 '@USER@'  => cleanID($user),
                 '@NAME@'  => cleanID($INFO['userinfo']['name']),
                 '@GROUP@' => cleanID($group),
-                '@LOCALE@'  => _get_language_of_wiki($id, $parent_id),
+                '@LOCALE@'  => $this->_get_language_of_wiki($id, $parent_id),
                 '@YEAR@'  => date('Y',$time_stamp),
                 '@MONTH@' => date('m',$time_stamp),
                 '@WEEK@' => date('W',$time_stamp),

--- a/helper.php
+++ b/helper.php
@@ -802,14 +802,16 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
        global $conf;
        $result = $conf['lang'];
        if(strpos($id, '@BROWSER_LANG@') !== false){
-           $brlangp = "/(^|,)([a-z][a-z](-[A-Z][A-Z])?)(;q=(0.[0-9]+))?/";
+           $brlangp = "/([a-zA-Z]{1,8}(-[a-zA-Z]{1,8})*|\*)(;q=(0(.[0-9]{0,3})?|1(.0{0,3})?))?/";
            if(preg_match_all(
                $brlangp, $_SERVER["HTTP_ACCEPT_LANGUAGE"],
                $matches, PREG_SET_ORDER
            )){
                $langs = array();
                foreach($matches as $match){
-                   $langs[$match[2]] = $match[5]==''?1.0:$match[5];
+                   $langname = $match[1] == '*' ? $conf['lang'] : $match[1];
+                   $qvalue = $match[4] == '' ? 1.0 : $match[4];
+                   $langs[$langname] = $qvalue;
                }
                arsort($langs);
                foreach($langs as $lang => $langq){
@@ -823,7 +825,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
            }                                                                                   
        }                                                                                       
        return cleanID($result);                                                                
-    }                                                                                          
+    }
     
     /**
      * Makes user or date dependent includes possible

--- a/helper.php
+++ b/helper.php
@@ -801,7 +801,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
     function _get_language_of_wiki($id, $parent_id) {
        global $conf;
        $result = $conf['lang'];
-       if(strpos($id, '@LOCALE@') !== false){
+       if(strpos($id, '@BROWSER_LANG@') !== false){
            $brlangp = "/(^|,)([a-z][a-z](-[A-Z][A-Z])?)(;q=(0.[0-9]+))?/";
            if(preg_match_all(
                $brlangp, $_SERVER["HTTP_ACCEPT_LANGUAGE"],
@@ -813,7 +813,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                }
                arsort($langs);
                foreach($langs as $lang => $langq){
-                   $testpage = $this->_apply_macro(str_replace('@LOCALE@', $lang, $id), $parent_id);
+                   $testpage = $this->_apply_macro(str_replace('@BROWSER_LANG@', $lang, $id), $parent_id);
                    resolve_pageid(getNS($parent_id), $testpage, $exists);
                    if($exists){
                        $result = $lang;
@@ -878,7 +878,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 '@USER@'  => cleanID($user),
                 '@NAME@'  => cleanID($INFO['userinfo']['name']),
                 '@GROUP@' => cleanID($group),
-                '@LOCALE@'  => $this->_get_language_of_wiki($id, $parent_id),
+                '@BROWSER_LANG@'  => $this->_get_language_of_wiki($id, $parent_id),
                 '@YEAR@'  => date('Y',$time_stamp),
                 '@MONTH@' => date('m',$time_stamp),
                 '@WEEK@' => date('W',$time_stamp),

--- a/helper.php
+++ b/helper.php
@@ -801,7 +801,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
     function _get_language_of_wiki($id, $parent_id) {
        global $conf;
        $result = $conf['lang'];
-       if(strpos($id, '@LANG@') !== false){
+       if(strpos($id, '@LOCALE@') !== false){
            $brlangp = "/(^|,)([a-z][a-z](-[A-Z][A-Z])?)(;q=(0.[0-9]+))?/";
            if(preg_match_all(
                $brlangp, $_SERVER["HTTP_ACCEPT_LANGUAGE"],
@@ -813,7 +813,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                }
                arsort($langs);
                foreach($langs as $lang => $langq){
-                   $testpage = $this->_apply_macro(str_replace('@LANG@', $lang, $id), $parent_id);
+                   $testpage = $this->_apply_macro(str_replace('@LOCALE@', $lang, $id), $parent_id);
                    resolve_pageid(getNS($parent_id), $testpage, $exists);
                    if($exists){
                        $result = $lang;
@@ -878,7 +878,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 '@USER@'  => cleanID($user),
                 '@NAME@'  => cleanID($INFO['userinfo']['name']),
                 '@GROUP@' => cleanID($group),
-                '@LANG@'  => _get_language_of_wiki($id, $parent_id),
+                '@LOCALE@'  => _get_language_of_wiki($id, $parent_id),
                 '@YEAR@'  => date('Y',$time_stamp),
                 '@MONTH@' => date('m',$time_stamp),
                 '@WEEK@' => date('W',$time_stamp),


### PR DESCRIPTION
From Issue #158 

## Feature
### The reason why I chose the name, @LOCALE@
First, I chose @LANG@ . 
But, @LANG@ conflicted with translation plugin's. (If we use page template and write `{{page>@LANG@}}` on this page,  when a instance be created with the template, it is transformed to `{{page>en}}` or others.)
So, I picked this.

However, I hesitate to judge.
There are @LC@, @INC_LANG@, etc.
Do you have better name?

### Macro change flow
1. Getting `HTTP_ACCEPT_LANGUAGE` from HTTP header
1. Try to translate page name and test to exist the page
1. If the page exists, this macro value is set
1. If there are many accept languages, check each items in the order
1. Else the macro sets wiki default

## Changes
- apply_macro function is changed to use resolve_pageid function.