### PR TITLE
Use an option to enable this plugins debug output

### DIFF
--- a/action.php
+++ b/action.php
@@ -131,7 +131,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
      */
     function handle_metadata(&$event, $param) {
         global $conf;
-        if($conf['allowdebug']) {
+        if($conf['allowdebug'] && $this->getConf('debugoutput')) {
             dbglog('---- PLUGIN INCLUDE META DATA START ----');
             dbglog($event->data);
             dbglog('---- PLUGIN INCLUDE META DATA END ----');
@@ -212,8 +212,8 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
         if(!isset($cache->mode) || $cache->mode == 'i') return;
 
         $depends = p_get_metadata($cache->page, 'plugin_include');
-        
-        if($conf['allowdebug']) {
+
+        if($conf['allowdebug'] && $this->getConf('debugoutput')) {
             dbglog('---- PLUGIN INCLUDE CACHE DEPENDS START ----');
             dbglog($depends);
             dbglog('---- PLUGIN INCLUDE CACHE DEPENDS END ----');
@@ -228,7 +228,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
             $depends['include_content'] != isset($_REQUEST['include_content'])) {
 
             $cache->depends['purge'] = true; // included pages changed or old metadata - request purge.
-            if($conf['allowdebug']) {
+            if($conf['allowdebug'] && $this->getConf('debugoutput')) {
                 dbglog('---- PLUGIN INCLUDE: REQUESTING CACHE PURGE ----');
                 dbglog('---- PLUGIN INCLUDE CACHE PAGES FROM META START ----');
                 dbglog($depends['pages']);

--- a/conf/default.php
+++ b/conf/default.php
@@ -26,4 +26,5 @@ $conf['order']        = 'id';    // order in which the pages are included in the
 $conf['rsort']        = 0;       // reverse sort order
 $conf['depth']        = 1;       // maximum depth of namespace includes, 0 for unlimited depth
 $conf['readmore']     = 1;       // Show readmore link in case of firstsection only
+$conf['debugoutput']  = 0;       // print debug information to debuglog if global allowdebug is enabled
 //Setup VIM: ex: et ts=2 :

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -29,4 +29,5 @@ $meta['order']         = array('multichoice', '_choices' => array('id', 'title',
 $meta['rsort']         = array('onoff');
 $meta['depth']         = array('numeric', '_min' => 0);
 $meta['readmore']      = array('onoff');
+$meta['debugoutput']   = array('onoff');
 //Setup VIM: ex: et ts=2 :

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -37,4 +37,5 @@ $lang['order_o_custom'] = 'custom order with include syntax';
 $lang['rsort']         = 'Reverse the sort order of the included pages';
 $lang['depth']         = 'Maximum depth of namespace includes, 0 for unlimited depth';
 $lang['readmore']       = 'Show or not the \'Read More\' link in case of firstsection only';
+$lang['debugoutput']    = 'Print verbose debug information to the dokuwiki debuglog if the global "allowdebug" option is enabled';
 //Setup VIM: ex: et ts=2 :


### PR DESCRIPTION
The debug output of this plugin is extremly verbose. It should be
possible to separately enable/disable it. That way the debug can still
be used when one is searching for rarer errors