### PR TITLE
Also query section IDs for format 'odt', not only for 'xhtml'. Fixes …

### DIFF
--- a/syntax/include.php
+++ b/syntax/include.php
@@ -124,7 +124,7 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
         }
 
         $secids = array();
-        if ($format == 'xhtml') {
+        if ($format == 'xhtml' || $format == 'odt') {
             $secids = p_get_metadata($ID, 'plugin_include secids');
         }
 


### PR DESCRIPTION
…#182.

Little change for ODT interworking. Please merge.