### PR TITLE
Compatibility with new section editing in DokuWiki Greebo, fix #223

### DIFF
--- a/syntax/editbtn.php
+++ b/syntax/editbtn.php
@@ -34,7 +34,12 @@ class syntax_plugin_include_editbtn extends DokuWiki_Syntax_Plugin {
     function render($mode, Doku_Renderer $renderer, $data) {
         list($title) = $data;
         if ($mode == 'xhtml') {
-            $renderer->startSectionEdit(0, 'plugin_include_editbtn', $title);
+            if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
+                $renderer->startSectionEdit(0, array('target' => 'plugin_include_editbtn', 'name' => $title));
+            } else {
+                $renderer->startSectionEdit(0, 'plugin_include_editbtn', $title);
+            }
+
             $renderer->finishSectionEdit();
             return true;
         }

--- a/syntax/header.php
+++ b/syntax/header.php
@@ -56,7 +56,11 @@ class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin {
             // the include header instruction is always at the beginning of the first section edit inside the include
             // wrap so there is no need to close a previous section edit.
             if ($lvl <= $conf['maxseclevel']) {
-                $classes[] = $renderer->startSectionEdit($pos, 'section', $headline);
+                if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
+                    $classes[] = $renderer->startSectionEdit($pos, array('target' => 'section', 'name' => $headline, 'hid' => $hid));
+                } else {
+                    $classes[] = $renderer->startSectionEdit($pos, 'section', $headline);
+                }
             }
             if ($classes) {
                 $renderer->doc .= ' class="'. implode(' ', $classes) . '"';

--- a/syntax/wrap.php
+++ b/syntax/wrap.php
@@ -36,14 +36,26 @@ class syntax_plugin_include_wrap extends DokuWiki_Syntax_Plugin {
             switch($state) {
                 case 'open':
                     if ($redirect) {
-                        $renderer->startSectionEdit(0, 'plugin_include_start', $page);
+                        if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
+                            $renderer->startSectionEdit(0, array('target' => 'plugin_include_start', 'name' => $page));
+                        } else {
+                            $renderer->startSectionEdit(0, 'plugin_include_start', $page);
+                        }
                     } else {
-                        $renderer->startSectionEdit(0, 'plugin_include_start_noredirect', $page);
+                        if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
+                            $renderer->startSectionEdit(0, array('target' => 'plugin_include_start_noredirect', 'name' => $page));
+                        } else {
+                            $renderer->startSectionEdit(0, 'plugin_include_start_noredirect', $page);
+                        }
                     }
                     $renderer->finishSectionEdit();
                     // Start a new section with type != section so headers in the included page
                     // won't print section edit buttons of the parent page
-                    $renderer->startSectionEdit(0, 'plugin_include_end', $page);
+                    if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
+                        $renderer->startSectionEdit(0, array('target' => 'plugin_include_end', 'name' => $page));
+                    } else {
+                        $renderer->startSectionEdit(0, 'plugin_include_end', $page);
+                    }
                     if ($secid === NULL) {
                         $id = '';
                     } else {


### PR DESCRIPTION
This is a basic compatibility fix. It would be nice if the edit button of the include plugin (for the whole included page) could also set the `hid` of the first header but this is not easily possible as that `hid` is not available globally (for this the code design would need to be changed). Further, the code block count won't be correct when multiple pages are included. This would probably need to be patched when the actual buttons are generated in the action plugin. For this, the actual code block count would need to be determined when scanning the instructions of the page to include (in particular when only a single section is included). I haven't implemented that yet and would move this to a new issue once this has been merged as I think basic compatibility is more important than correct code block counts.