### PR TITLE
change metadata storage location

### DIFF
--- a/action.php
+++ b/action.php
@@ -48,7 +48,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
      * Add a version string to the index so it is rebuilt
      * whenever the handler is updated or the safeindex setting is changed
      */
-    public function handle_indexer_version($event, $param) {
+    public function handle_indexer_version(Doku_Event $event, $param) {
         $event->data['plugin_include'] = '0.1.safeindex='.$this->getConf('safeindex');
     }
 
@@ -129,7 +129,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
     /**
      * Used for debugging purposes only
      */
-    function handle_metadata(&$event, $param) {
+    function handle_metadata(Doku_Event $event, $param) {
         global $conf;
         if($conf['allowdebug'] && $this->getConf('debugoutput')) {
             dbglog('---- PLUGIN INCLUDE META DATA START ----');
@@ -176,7 +176,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
     /**
      * Add a hidden input to the form to preserve the redirect_id
      */
-    function handle_form(Doku_Event &$event, $param) {
+    function handle_form(Doku_Event $event, $param) {
       if (array_key_exists('redirect_id', $_REQUEST)) {
         $event->data->addHidden('redirect_id', cleanID($_REQUEST['redirect_id']));
       }
@@ -185,7 +185,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
     /**
      * Modify the data for the redirect when there is a redirect_id set
      */
-    function handle_redirect(Doku_Event &$event, $param) {
+    function handle_redirect(Doku_Event $event, $param) {
       if (array_key_exists('redirect_id', $_REQUEST)) {
         // Render metadata when this is an older DokuWiki version where
         // metadata is not automatically re-rendered as the page has probably
@@ -202,7 +202,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
     /**
      * prepare the cache object for default _useCache action
      */
-    function _cache_prepare(Doku_Event &$event, $param) {
+    function _cache_prepare(Doku_Event $event, $param) {
         global $conf;
 
         /* @var cache_renderer $cache */
@@ -256,7 +256,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
      * and replace normal section edit buttons when the current page is different from the
      * global $ID.
      */
-    function handle_secedit_button(Doku_Event &$event, $params) {
+    function handle_secedit_button(Doku_Event $event, $params) {
         // stack of included pages in the form ('id' => page, 'rev' => modification time, 'writable' => bool)
         static $page_stack = array();
 

--- a/action.php
+++ b/action.php
@@ -68,7 +68,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
         if (is_null($USERINFO) && !isset($_SERVER['REMOTE_USER'])) return;
 
         // get the include metadata in order to see which pages were included
-        $inclmeta = p_get_metadata($event->data['page'], 'plugin_include', METADATA_RENDER_UNLIMITED);
+        $inclmeta = p_get_metadata($event->data['page'], 'plugin include', METADATA_RENDER_UNLIMITED);
         $all_public = true; // are all included pages public?
         // check if the current metadata indicates that non-public pages were included
         if ($inclmeta !== null && isset($inclmeta['pages'])) {
@@ -211,7 +211,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
         if(!isset($cache->page)) return;
         if(!isset($cache->mode) || $cache->mode == 'i') return;
 
-        $depends = p_get_metadata($cache->page, 'plugin_include');
+        $depends = p_get_metadata($cache->page, 'plugin include');
 
         if($conf['allowdebug'] && $this->getConf('debugoutput')) {
             dbglog('---- PLUGIN INCLUDE CACHE DEPENDS START ----');

--- a/helper.php
+++ b/helper.php
@@ -545,7 +545,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      * @param string $page           The included page
      * @param array  $included_pages The array of pages that are included
      */
-    private function adapt_links(&$ins, $page, $included_pages = null) {
+    private function adapt_links(&$ins, $page, $included_pages = array()) {
         $num = count($ins);
         $ns  = getNS($page);
 
@@ -607,7 +607,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                     break;
                 case 'locallink':
                     /* Convert local links to internal links if the page hasn't been fully included */
-                    if ($included_pages == null || !array_key_exists($page, $included_pages)) {
+                    if (!array_key_exists($page, $included_pages)) {
                         $ins[$i][0] = 'internallink';
                         $ins[$i][1][0] = ':'.$page.'#'.$ins[$i][1][0];
                     }

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -109,6 +109,8 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
 
         if ($format == 'metadata') {
             /** @var Doku_Renderer_metadata $renderer */
+            $renderer->meta['plugin']['include'] = [];
+            $metadata =& $renderer->meta['plugin']['include'];
 
             // remove old persistent metadata of previous versions of the include plugin
             if (isset($renderer->persistent['plugin_include'])) {
@@ -116,16 +118,17 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
                 unset($renderer->meta['plugin_include']);
             }
 
-            $renderer->meta['plugin_include']['instructions'][] = compact('mode', 'page', 'sect', 'parent_id', $flags);
-            if (!isset($renderer->meta['plugin_include']['pages']))
-               $renderer->meta['plugin_include']['pages'] = array(); // add an array for array_merge
-            $renderer->meta['plugin_include']['pages'] = array_merge($renderer->meta['plugin_include']['pages'], $pages);
-            $renderer->meta['plugin_include']['include_content'] = isset($_REQUEST['include_content']);
+            $metadata['instructions'][] = compact('mode', 'page', 'sect', 'parent_id', $flags);
+            if (!isset($metadata['pages']))
+               $metadata['pages'] = array(); // add an array for array_merge
+            $metadata['pages'] = array_merge($metadata['pages'], $pages);
+            $metadata['include_content'] = isset($_REQUEST['include_content']);
         }
 
         $secids = array();
         if ($format == 'xhtml' || $format == 'odt') {
-            $secids = p_get_metadata($ID, 'plugin_include secids');
+            global $INFO;
+            $secids = $INFO['meta']['plugin']['include']['secids'];
         }
 
         foreach ($pages as $page) {
@@ -140,8 +143,8 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
             if ($format == 'metadata') {
                 $renderer->meta['relation']['references'][$id] = $exists;
                 $renderer->meta['relation']['haspart'][$id]    = $exists;
-                if (!$sect && !$flags['firstsec'] && !$flags['linkonly'] && !isset($renderer->meta['plugin_include']['secids'][$id])) {
-                    $renderer->meta['plugin_include']['secids'][$id] = array('hid' => 'plugin_include__'.str_replace(':', '__', $id), 'pos' => $pos);
+                if (!$sect && !$flags['firstsec'] && !$flags['linkonly'] && !isset($metadata['secids'][$id])) {
+                    $metadata['secids'][$id] = array('hid' => 'plugin_include__'.str_replace(':', '__', $id), 'pos' => $pos);
                 }
             }
 

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -128,7 +128,9 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
         $secids = array();
         if ($format == 'xhtml' || $format == 'odt') {
             global $INFO;
-            $secids = $INFO['meta']['plugin']['include']['secids'];
+            if (isset($INFO['meta']['plugin']['include']['secids'])) {
+                $secids = $INFO['meta']['plugin']['include']['secids'];
+            }
         }
 
         foreach ($pages as $page) {


### PR DESCRIPTION
For plugin internal data, it is recommended to store plugin's own keys under the plugin key:
`$meta['plugin']['include']` instead of `$meta['plugin_include']`. 