### PR TITLE
Add 'exclude' option

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -224,6 +224,9 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 case 'noreadmore':
                     $flags['readmore'] = 0;
                     break;
+                case 'exclude':
+                    $flags['exclude'] = $value;
+                    break;
             }
         }
         // the include_content URL parameter overrides flags
@@ -303,9 +306,9 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
         }
 
         if($flags['firstsec']) {
-            $this->_get_firstsec($ins, $page, $flags);  // only first section 
+            $this->_get_firstsec($ins, $page, $flags);  // only first section
         }
-        
+
         $ns  = getNS($page);
         $num = count($ins);
 
@@ -452,7 +455,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                     } else {
                         $footer_lvl = $lvl_max;
                     }
-                } 
+                }
             }
         }
 
@@ -530,7 +533,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
 
     /**
      * Convert instruction item for a permalink header
-     * 
+     *
      * @author Michael Klier <chi@chimeric.de>
      */
     function _permalink(&$ins, $page, $sect, $flags) {
@@ -616,11 +619,11 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
         }
     }
 
-    /** 
-     * Get a section including its subsections 
+    /**
+     * Get a section including its subsections
      *
      * @author Michael Klier <chi@chimeric.de>
-     */ 
+     */
     function _get_section(&$ins, $sect) {
         $num = count($ins);
         $offset = false;
@@ -631,12 +634,12 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
         $check = array(); // used for sectionID() in order to get the same ids as the xhtml renderer
 
         for($i=0; $i<$num; $i++) {
-            if ($ins[$i][0] == 'header') { 
+            if ($ins[$i][0] == 'header') {
 
-                // found the right header 
+                // found the right header
                 if (sectionID($ins[$i][1][0], $check) == $sect) {
                     $offset = $i;
-                    $lvl    = $ins[$i][1][1]; 
+                    $lvl    = $ins[$i][1][1];
                 } elseif ($offset && $lvl && ($ins[$i][1][1] <= $lvl)) {
                     $end = $i - $offset;
                     $endpos = $ins[$i][1][2]; // the position directly after the found section, needed for the section edit button
@@ -651,7 +654,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
             // store the end position in the include_closelastsecedit instruction so it can generate a matching button
             $ins[] = array('plugin', array('include_closelastsecedit', array($endpos)));
         }
-    } 
+    }
 
     /**
      * Only display the first section of a page and a readmore link
@@ -816,7 +819,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
         }
         return $pages;
     }
-    
+
     /**
      *  Get wiki language from "HTTP_ACCEPT_LANGUAGE"
      *  We allow the pattern e.g. "ja,en-US;q=0.7,en;q=0.3"
@@ -845,18 +848,18 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                        break;
                    }
                }
-           }                                                                                   
-       }                                                                                       
-       return cleanID($result);                                                                
+           }
+       }
+       return cleanID($result);
     }
-    
+
     /**
      * Makes user or date dependent includes possible
      */
     function _apply_macro($id, $parent_id) {
         global $INFO;
         global $auth;
-        
+
         // if we don't have an auth object, do nothing
         if (!$auth) return $id;
 

--- a/helper.php
+++ b/helper.php
@@ -736,6 +736,12 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 $pages[] = $page;
         }
 
+        $pages = array_filter($pages, function ($page) use ($flags) {
+            if (isset($flags['exclude']) && @preg_match($flags['exclude'], $page))
+                return FALSE;
+            return TRUE;
+        });
+
         if (count($pages) > 1) {
             if ($flags['order'] === 'id') {
                 if ($flags['rsort']) {

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -133,8 +133,6 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
             $id = $page['id'];
             $exists = $page['exists'];
 
-            if (isset($flags['exclude']) && @preg_match($flags['exclude'], $id)) continue;
-
             if (in_array($id, $page_stack)) continue;
             array_push($page_stack, $id);
 

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -136,7 +136,7 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
             if (in_array($id, $page_stack)) continue;
             array_push($page_stack, $id);
 
-            if (preg_match($flags['exclude'], $id)) continue;
+            if (isset($flags['exclude']) && preg_match($flags['exclude'], $id)) continue;
 
             // add references for backlink
             if ($format == 'metadata') {

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -133,10 +133,10 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
             $id = $page['id'];
             $exists = $page['exists'];
 
+            if (isset($flags['exclude']) && preg_match($flags['exclude'], $id)) continue;
+
             if (in_array($id, $page_stack)) continue;
             array_push($page_stack, $id);
-
-            if (isset($flags['exclude']) && preg_match($flags['exclude'], $id)) continue;
 
             // add references for backlink
             if ($format == 'metadata') {

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -1,28 +1,28 @@
-<?php 
-/** 
- * Include Plugin: displays a wiki page within another 
- * Usage: 
- * {{page>page}} for "page" in same namespace 
- * {{page>:page}} for "page" in top namespace 
- * {{page>namespace:page}} for "page" in namespace "namespace" 
- * {{page>.namespace:page}} for "page" in subnamespace "namespace" 
- * {{page>page#section}} for a section of "page" 
- * 
- * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html) 
+<?php
+/**
+ * Include Plugin: displays a wiki page within another
+ * Usage:
+ * {{page>page}} for "page" in same namespace
+ * {{page>:page}} for "page" in top namespace
+ * {{page>namespace:page}} for "page" in namespace "namespace"
+ * {{page>.namespace:page}} for "page" in subnamespace "namespace"
+ * {{page>page#section}} for a section of "page"
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Esther Brunner <wikidesign@gmail.com>
  * @author     Christopher Smith <chris@jalakai.co.uk>
  * @author     Gina Häußge, Michael Klier <dokuwiki@chimeric.de>
- */ 
- 
-if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/'); 
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/'); 
-require_once(DOKU_PLUGIN.'syntax.php'); 
-  
-/** 
- * All DokuWiki plugins to extend the parser/rendering mechanism 
- * need to inherit from this class 
- */ 
-class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin { 
+ */
+
+if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/');
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+require_once(DOKU_PLUGIN.'syntax.php');
+
+/**
+ * All DokuWiki plugins to extend the parser/rendering mechanism
+ * need to inherit from this class
+ */
+class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
 
     /** @var $helper helper_plugin_include */
     var $helper = null;
@@ -53,11 +53,11 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
      *
      * @param $mode mixed The current mode
      */
-    function connectTo($mode) {  
-        $this->Lexer->addSpecialPattern("{{page>.+?}}", $mode, 'plugin_include_include');  
-        $this->Lexer->addSpecialPattern("{{section>.+?}}", $mode, 'plugin_include_include'); 
-        $this->Lexer->addSpecialPattern("{{namespace>.+?}}", $mode, 'plugin_include_include'); 
-        $this->Lexer->addSpecialPattern("{{tagtopic>.+?}}", $mode, 'plugin_include_include'); 
+    function connectTo($mode) {
+        $this->Lexer->addSpecialPattern("{{page>.+?}}", $mode, 'plugin_include_include');
+        $this->Lexer->addSpecialPattern("{{section>.+?}}", $mode, 'plugin_include_include');
+        $this->Lexer->addSpecialPattern("{{namespace>.+?}}", $mode, 'plugin_include_include');
+        $this->Lexer->addSpecialPattern("{{tagtopic>.+?}}", $mode, 'plugin_include_include');
     }
 
     /**
@@ -74,8 +74,8 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
         $match = substr($match, 2, -2); // strip markup
         list($match, $flags) = explode('&', $match, 2);
 
-        // break the pattern up into its parts 
-        list($mode, $page, $sect) = preg_split('/>|#/u', $match, 3); 
+        // break the pattern up into its parts
+        list($mode, $page, $sect) = preg_split('/>|#/u', $match, 3);
         $check = false;
         if (isset($sect)) $sect = sectionID($sect, $check);
         $level = NULL;
@@ -135,6 +135,8 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
 
             if (in_array($id, $page_stack)) continue;
             array_push($page_stack, $id);
+
+            if (preg_match($flags['exclude'], $id)) continue;
 
             // add references for backlink
             if ($format == 'metadata') {

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -133,7 +133,7 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
             $id = $page['id'];
             $exists = $page['exists'];
 
-            if (isset($flags['exclude']) && preg_match($flags['exclude'], $id)) continue;
+            if (isset($flags['exclude']) && @preg_match($flags['exclude'], $id)) continue;
 
             if (in_array($id, $page_stack)) continue;
             array_push($page_stack, $id);


### PR DESCRIPTION
This PR adds an 'exclude' option that takes a regular expression as value. Pages of which the id matches the regular expression will be excluded. E.g.:

```
{{namespace>test&exclude=/test:some_page/}}
```

Looking at the diff, my editor also removed some trailing whitespace...