### PR TITLE
Added option to include backlinking pages

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -735,7 +735,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
             @require_once(DOKU_INC.'inc/fulltext.php');
             $pagearrays = ft_backlinks($page,true);
             $this->taghelper =& plugin_load('helper', 'tag');
-            $tags = $this->taghelper->getTopic('notes', null, 'note');
+            $tags = $this->taghelper->getTopic(getNS($parent_id), null, $sect);
             foreach ($tags as $tag){
                 $tagss[] = $tag['id'];
             }
@@ -746,7 +746,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                     }
                  }
             }else{
-                $pages[] = 'dummy';
+                $pages[] = 'nobacklinksyet';
             }
             break;
         default:

--- a/helper.php
+++ b/helper.php
@@ -729,6 +729,26 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 $pages[] = $pagearray['id'];
             }
             break;
+        case 'backlinks':
+            $page = $this->_apply_macro($page, $parent_id);
+            resolve_pageid(getNS($parent_id), $page, $exists);
+            @require_once(DOKU_INC.'inc/fulltext.php');
+            $pagearrays = ft_backlinks($page,true);
+            $this->taghelper =& plugin_load('helper', 'tag');
+            $tags = $this->taghelper->getTopic('notes', null, 'note');
+            foreach ($tags as $tag){
+                $tagss[] = $tag['id'];
+            }
+            if(!empty($pagearrays)){
+                foreach ($pagearrays as $pagearray) {
+                    if(in_array($pagearray,$tagss)){
+                        $pages[] = $pagearray;
+                    }
+                 }
+            }else{
+                $pages[] = 'dummy';
+            }
+            break;
         default:
             $page = $this->_apply_macro($page, $parent_id);
             resolve_pageid(getNS($parent_id), $page, $exists); // resolve shortcuts and clean ID

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -58,6 +58,7 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern("{{section>.+?}}", $mode, 'plugin_include_include');
         $this->Lexer->addSpecialPattern("{{namespace>.+?}}", $mode, 'plugin_include_include');
         $this->Lexer->addSpecialPattern("{{tagtopic>.+?}}", $mode, 'plugin_include_include');
+        $this->Lexer->addSpecialPattern("{{backlinks>.+?}}", $mode, 'plugin_include_include');
     }
 
     /**


### PR DESCRIPTION
Hi,

I have tried to add an option so that you can use 
```
{{backlinks>[pagename]#[includetag]&[flags]}}
```
in addition to tagtopic etc. It will include the pages linking to [pagename]. Only pages tagged with the provided [includetag] will be included. It only looks in the namespace of [pagename].