### PR TITLE
Improve editing support and fix #245

### DIFF
--- a/action.php
+++ b/action.php
@@ -285,8 +285,10 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
             if ($page_stack[0]['writable']) {
                 $params = array('do' => 'edit',
                     'id' => $page_stack[0]['id']);
-                if ($page_stack[0]['redirect'])
+                if ($page_stack[0]['redirect']) {
                     $params['redirect_id'] = $ID;
+                    $params['hid'] = $data['hid'];
+                }
                 $event->result = '<div class="secedit">' . DOKU_LF .
                     html_btn('incledit', $page_stack[0]['id'], '',
                         $params, 'post',

--- a/helper.php
+++ b/helper.php
@@ -457,9 +457,11 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
             array_push($ins, array('plugin', array('include_closelastsecedit', array($endpos))));
         }
 
+        $include_secid = (isset($flags['include_secid']) ? $flags['include_secid'] : NULL);
+
         // add edit button
         if($flags['editbtn']) {
-            $this->_editbtn($ins, $page, $sect, $sect_title, ($flags['redirect'] ? $root_id : false));
+            $this->_editbtn($ins, $page, $sect, $sect_title, ($flags['redirect'] ? $root_id : false), $include_secid);
         }
 
         // add footer
@@ -484,7 +486,6 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
         }
 
         // add instructions entry wrapper
-        $include_secid = (isset($flags['include_secid']) ? $flags['include_secid'] : NULL);
         array_unshift($ins, array('plugin', array('include_wrap', array('open', $page, $flags['redirect'], $include_secid))));
         if (isset($flags['beforeeach']))
             array_unshift($ins, array('entity', array($flags['beforeeach'])));
@@ -516,11 +517,11 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function _editbtn(&$ins, $page, $sect, $sect_title, $root_id) {
+    function _editbtn(&$ins, $page, $sect, $sect_title, $root_id, $hid = '') {
         $title = ($sect) ? $sect_title : $page;
         $editbtn = array();
         $editbtn[0] = 'plugin';
-        $editbtn[1] = array('include_editbtn', array($title));
+        $editbtn[1] = array('include_editbtn', array($title, $hid));
         $ins[] = $editbtn;
     }
 

--- a/syntax/editbtn.php
+++ b/syntax/editbtn.php
@@ -26,10 +26,10 @@ class syntax_plugin_include_editbtn extends DokuWiki_Syntax_Plugin {
      * @author Michael Klier <chi@chimeric.de>
      */
     function render($mode, Doku_Renderer $renderer, $data) {
-        list($title) = $data;
+        list($title, $hid) = $data;
         if ($mode == 'xhtml') {
             if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
-                $renderer->startSectionEdit(0, array('target' => 'plugin_include_editbtn', 'name' => $title));
+                $renderer->startSectionEdit(0, array('target' => 'plugin_include_editbtn', 'name' => $title, 'hid' => $hid));
             } else {
                 $renderer->startSectionEdit(0, 'plugin_include_editbtn', $title);
             }

--- a/syntax/wrap.php
+++ b/syntax/wrap.php
@@ -30,18 +30,19 @@ class syntax_plugin_include_wrap extends DokuWiki_Syntax_Plugin {
      */
     function render($mode, Doku_Renderer $renderer, $data) {
         if ($mode == 'xhtml') {
-            list($state, $page, $redirect, $secid) = $data;
+            $state = array_shift($data);
             switch($state) {
                 case 'open':
+                    list($page, $redirect, $secid) = $data;
                     if ($redirect) {
                         if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
-                            $renderer->startSectionEdit(0, array('target' => 'plugin_include_start', 'name' => $page));
+                            $renderer->startSectionEdit(0, array('target' => 'plugin_include_start', 'name' => $page, 'hid' => ''));
                         } else {
                             $renderer->startSectionEdit(0, 'plugin_include_start', $page);
                         }
                     } else {
                         if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
-                            $renderer->startSectionEdit(0, array('target' => 'plugin_include_start_noredirect', 'name' => $page));
+                            $renderer->startSectionEdit(0, array('target' => 'plugin_include_start_noredirect', 'name' => $page, 'hid' => ''));
                         } else {
                             $renderer->startSectionEdit(0, 'plugin_include_start_noredirect', $page);
                         }
@@ -50,7 +51,7 @@ class syntax_plugin_include_wrap extends DokuWiki_Syntax_Plugin {
                     // Start a new section with type != section so headers in the included page
                     // won't print section edit buttons of the parent page
                     if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
-                        $renderer->startSectionEdit(0, array('target' => 'plugin_include_end', 'name' => $page));
+                        $renderer->startSectionEdit(0, array('target' => 'plugin_include_end', 'name' => $page, 'hid' => ''));
                     } else {
                         $renderer->startSectionEdit(0, 'plugin_include_end', $page);
                     }


### PR DESCRIPTION
This should fix the remaining undefined index warnings raised in #245. Further, this explicitly passes the include plugin's section ids to the edit form to support redirecting directly to the included page from the page edit form. I have also fixed support for the new events in DokuWiki's master branch.