### PR TITLE
New noinstructionscache flag

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -220,6 +220,9 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 case 'exclude':
                     $flags['exclude'] = $value;
                     break;
+                case 'noinstructionscache':
+                    $flags['noinstructionscache'] = 1;
+                    break;
             }
         }
         // the include_content URL parameter overrides flags
@@ -266,7 +269,11 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 global $ID;
                 $backupID = $ID;
                 $ID = $page; // Change the global $ID as otherwise plugins like the discussion plugin will save data for the wrong page
-                $ins = p_cached_instructions(wikiFN($page), false, $page);
+                if ($flags['noinstructionscache']) {
+                    $ins = p_get_instructions(io_readWikiPage(wikiFN($page), $page));
+                } else {
+                    $ins = p_cached_instructions(wikiFN($page), false, $page);
+                }
                 $ID = $backupID;
             } else {
                 $ins = array();


### PR DESCRIPTION
This commit adds a new flag: noinstructionscache to plugin syntax. This flag forces not to use an instruction cache for the included page. This flag allows using the struct serial aggregation inside the included page. More generally, it allows using any DokuWiki syntax which instructions are dependant on the current page id, inside the included page.