### PR TITLE
Add parameter support for wikimedia style template

### DIFF
--- a/action.php
+++ b/action.php
@@ -145,7 +145,6 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
 
         $level = 0;
         $ins =& $event->data->calls;
-        dbglog($ins);
         $num = count($ins);
         for($i=0; $i<$num; $i++) {
             switch($ins[$i][0]) {

--- a/action.php
+++ b/action.php
@@ -145,13 +145,14 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
 
         $level = 0;
         $ins =& $event->data->calls;
+        dbglog($ins);
         $num = count($ins);
         for($i=0; $i<$num; $i++) {
             switch($ins[$i][0]) {
             case 'plugin':
                 switch($ins[$i][1][0]) {
                 case 'include_include':
-                    $ins[$i][1][1][5] = $level;
+                    $ins[$i][1][1][4] = $level;
                     break;
                     /* FIXME: this doesn't work anymore that way with the new structure
                     // some plugins already close open sections
@@ -330,11 +331,12 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
 
     public function rewrite_include($match, $pos, $state, $plugin, helper_plugin_move_handler $handler) {
         $syntax = substr($match, 2, -2); // strip markup
+        // $replacers = explode('|', $syntax);
+        // $syntax = array_shift($replacers);
+        list($syntax, $flags) = array_pad(preg_split('/(?<!\\\\)&/', $syntax, 2), 2, null);
 
         // break the pattern up into its parts
-        list($syntax, $params) = array_pad(preg_split('/(?<!\\\\)\\|/', $syntax, 2), 2, null);
-        list($syntax, $flags) = array_pad(preg_split('/(?<!\\\\)&/', $syntax, 2), 2, null);
-        list($mode, $page, $sect) = preg_split('/>|#/', $syntax, 3);
+        list($mode, $page, $sect) = preg_split('/>|#/u', $syntax, 3);
 
         if (method_exists($handler, 'adaptRelativeId')) { // move plugin before version 2015-05-16
             $newpage = $handler->adaptRelativeId($page);
@@ -349,10 +351,13 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
             $result = '{{'.$mode.'>'.$newpage;
             if ($sect) $result .= '#'.$sect;
             if ($flags) $result .= '&'.$flags;
-            if ($params) $result .= '|'.$params;
-            $result .= '}}';
-            return $result;
+            // if ($replacers) $result .= '|'.$replacers;
+
+        $result .= '}}';
+        return $result;
         }
+        
     }
+
 }
 // vim:ts=4:sw=4:et:

--- a/action.php
+++ b/action.php
@@ -151,7 +151,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
             case 'plugin':
                 switch($ins[$i][1][0]) {
                 case 'include_include':
-                    $ins[$i][1][1][4] = $level;
+                    $ins[$i][1][1][5] = $level;
                     break;
                     /* FIXME: this doesn't work anymore that way with the new structure
                     // some plugins already close open sections
@@ -330,12 +330,11 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
 
     public function rewrite_include($match, $pos, $state, $plugin, helper_plugin_move_handler $handler) {
         $syntax = substr($match, 2, -2); // strip markup
-        $replacers = explode('|', $syntax);
-        $syntax = array_shift($replacers);
-        list($syntax, $flags) = explode('&', $syntax, 2);
 
         // break the pattern up into its parts
-        list($mode, $page, $sect) = preg_split('/>|#/u', $syntax, 3);
+        list($syntax, $params) = array_pad(preg_split('/(?<!\\\\)\\|/', $syntax, 2), 2, null);
+        list($syntax, $flags) = array_pad(preg_split('/(?<!\\\\)&/', $syntax, 2), 2, null);
+        list($mode, $page, $sect) = preg_split('/>|#/', $syntax, 3);
 
         if (method_exists($handler, 'adaptRelativeId')) { // move plugin before version 2015-05-16
             $newpage = $handler->adaptRelativeId($page);
@@ -350,7 +349,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
             $result = '{{'.$mode.'>'.$newpage;
             if ($sect) $result .= '#'.$sect;
             if ($flags) $result .= '&'.$flags;
-            if ($replacers) $result .= '|'.$replacers;
+            if ($params) $result .= '|'.$params;
             $result .= '}}';
             return $result;
         }

--- a/helper.php
+++ b/helper.php
@@ -234,7 +234,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      * @author Michael Klier <chi@chimeric.de>
      * @author Michael Hamann <michael@content-space.de>
      */
-    function _get_instructions($page, $sect, $mode, $lvl, $flags, $root_id = null, $included_pages = array()) {
+    function _get_instructions($page, $sect, $mode, $lvl, $flags, $params, $root_id = null, $included_pages = array()) {
         $key = ($sect) ? $page . '#' . $sect : $page;
         $this->includes[$key] = true; // legacy code for keeping compatibility with other plugins
 
@@ -272,7 +272,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 $ins = array();
             }
 
-            $this->_convert_instructions($ins, $lvl, $page, $sect, $flags, $root_id, $included_pages);
+            $this->_convert_instructions($ins, $lvl, $page, $sect, $flags, $params, $root_id, $included_pages);
         }
         return $ins;
     }
@@ -290,7 +290,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function _convert_instructions(&$ins, $lvl, $page, $sect, $flags, $root_id, $included_pages = array()) {
+    function _convert_instructions(&$ins, $lvl, $page, $sect, $flags, $params, $root_id, $included_pages = array()) {
+
         global $conf;
 
         // filter instructions if needed
@@ -366,8 +367,18 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                             break;
                         // adapt indentation level of nested includes
                         case 'include_include':
-                            if (!$flags['inline'] && $flags['indent'])
+                            if (!$flags['inline'] && $flags['indent']) {
                                 $ins[$i][1][1][4] += $lvl;
+                            }
+                            break;
+                        case 'include_placeholder':
+                            if (array_key_exists($ins[$i][1][1][0], $params)) {
+                                $ins[$i] = array(
+                                    "cdata",
+                                    array($params[$ins[$i][1][1][0]]),
+                                    $ins[$i][1][1][1]
+                                );
+                            }
                             break;
                         /*
                          * if there is already a closelastsecedit instruction (was added by one of the section
@@ -691,7 +702,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      *
      * @author Michael Hamann <michael@content-space.de>
      */
-    function _get_included_pages($mode, $page, $sect, $parent_id, $flags) {
+    function _get_included_pages($mode, $page, $sect, $parent_id, $flags, $params) {
         global $conf;
         $pages = array();
         switch($mode) {
@@ -815,7 +826,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
             $sect      = $instruction['sect'];
             $parent_id = $instruction['parent_id'];
             $flags     = $instruction['flags'];
-            $pages = array_merge($pages, $this->_get_included_pages($mode, $page, $sect, $parent_id, $flags));
+            $params    = $instruction['params'];
+            $pages = array_merge($pages, $this->_get_included_pages($mode, $page, $sect, $parent_id, $flags, $params));
         }
         return $pages;
     }

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -68,31 +68,7 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
     function handle($match, $state, $pos, Doku_Handler $handler) {
 
         $match = substr($match, 2, -2); // strip markup
-
-        // Strip out parameters.
-        list($match, $parameter) = array_pad(preg_split('/(?<!\\\\)\\|/', $match, 2), 2, '');
-
-        $param_array = array();
-
-        if ($parameter != '') {
-            // Process parameters if exist.
-            $count = 0;
-            $parameter = preg_split('/(?<!\\\\)\\|/', $parameter);
-            foreach($parameter as $param) {
-                if (preg_match('/(?<!\\\\)=/', $param)) {
-                    // There's one '=' character: This is named parameter.
-                    list($name, $value) = preg_split('/(?<!\\\\)=/', $param, 2);
-                    $param_array[$name] = $this->_escape_value($value);
-                } else {
-                    // There's no '=' character: This is unnamed parameter.
-                    $count += 1;
-                    $param_array[strval($count)] = $this->_escape_value($param);
-                }
-            }
-        }
-
-        // Strip out flags.
-        list($match, $flags) = array_pad(preg_split('/(?<!\\\\)&/', $match, 2), 2, '');
+        list($match, $flags) = array_pad(explode('&', $match, 2), 2, '');
 
         // break the pattern up into its parts
         list($mode, $page, $sect) = array_pad(preg_split('/>|#/u', $match, 3), 3, null);
@@ -100,14 +76,7 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
         if (isset($sect)) $sect = sectionID($sect, $check);
         $level = NULL;
 
-        return array($mode, $page, $sect, explode('&', $flags), $param_array, $level, $pos);
-    }
-
-    /**
-     * Escapes '\|', '\&', '\=', '\}' in parameter value.
-     */
-    function _escape_value($value) {
-        return preg_replace('/\\\\([|&=}])/', '\1', $value);
+        return array($mode, $page, $sect, preg_split('/(?<!\\\\)&/', $flags), $level, $pos);
     }
 
     /**
@@ -127,13 +96,13 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
         $parent_id = $page_stack[count($page_stack)-1];
         $root_id = $page_stack[0];
 
-        list($mode, $page, $sect, $flags, $params, $level, $pos) = $data;
+        list($mode, $page, $sect, $flags, $level, $pos) = $data;
 
         if (!$this->helper)
             $this->helper = plugin_load('helper', 'include');
         $flags = $this->helper->get_flags($flags);
 
-        $pages = $this->helper->_get_included_pages($mode, $page, $sect, $parent_id, $flags, $params);
+        $pages = $this->helper->_get_included_pages($mode, $page, $sect, $parent_id, $flags);
 
         if ($format == 'metadata') {
             /** @var Doku_Renderer_metadata $renderer */
@@ -144,14 +113,11 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
                 unset($renderer->meta['plugin_include']);
             }
 
-            $renderer->meta['plugin_include']['instructions'][] = compact('mode', 'page', 'sect', 'parent_id', 'flags', 'params');
-
+            $renderer->meta['plugin_include']['instructions'][] = compact('mode', 'page', 'sect', 'parent_id', 'flags');
             if (!isset($renderer->meta['plugin_include']['pages']))
                $renderer->meta['plugin_include']['pages'] = array(); // add an array for array_merge
             $renderer->meta['plugin_include']['pages'] = array_merge($renderer->meta['plugin_include']['pages'], $pages);
             $renderer->meta['plugin_include']['include_content'] = isset($_REQUEST['include_content']);
-            $renderer->meta['plugin_include']['params'] = $params;
-
         }
 
         $secids = array();
@@ -182,7 +148,7 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
                 unset($flags['include_secid']);
             }
 
-            $instructions = $this->helper->_get_instructions($id, $sect, $mode, $level, $flags, $params, $root_id, $secids);
+            $instructions = $this->helper->_get_instructions($id, $sect, $mode, $level, $flags, $root_id, $secids);
 
             if (!$flags['editbtn']) {
                 global $conf;

--- a/syntax/placeholder.php
+++ b/syntax/placeholder.php
@@ -50,9 +50,11 @@ class syntax_plugin_include_placeholder extends DokuWiki_Syntax_Plugin {
     }
 
     /**
-     * Skip rendering of template field.
+     * Render template field as bold, italic text.
      */
     function render($format, Doku_Renderer $renderer, $data) {
+        if ($format !== 'xhtml') return false;
+        $renderer->doc .= "<i><b>{{{".$data[0]."}}}</b></i>";
         return true;
     }
 

--- a/syntax/placeholder.php
+++ b/syntax/placeholder.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Include Plugin parameter
+ */
+
+ /**
+  * All DokuWiki plugins to extend the parser/rendering mechanism
+  * need to inherit from this class
+  */
+class syntax_plugin_include_placeholder extends DokuWiki_Syntax_Plugin {
+
+    /** @var $helper helper_plugin_include */
+    var $helper = null;
+
+    /**
+     * Get syntax plugin type.
+     *
+     * @return string The plugin type.
+     */
+    function getType() { return 'substition'; }
+
+    /**
+     * Get sort order of syntax plugin.
+     *
+     * @return int The sort order.
+     */
+    function getSort() { return 300; }
+
+    /**
+     * Connect patterns/modes
+     *
+     * @param $mode mixed The current mode
+     */
+    function connectTo($mode) {
+        $this->Lexer->addSpecialPattern("{{{.+?}}}", $mode, 'plugin_include_placeholder');
+    }
+
+    /**
+     * Handle syntax matches
+     *
+     * @param string       $match   The current match
+     * @param int          $state   The match state
+     * @param int          $pos     The position of the match
+     * @param Doku_Handler $handler The hanlder object
+     * @return array The instructions of the plugin
+     */
+    function handle($match, $state, $pos, Doku_handler $handler) {
+        $name = substr($match, 3, -3);  // strip markup
+        return array($name, $pos);
+    }
+
+    /**
+     * Skip rendering of template field.
+     */
+    function render($format, Doku_Renderer $renderer, $data) {
+        return true;
+    }
+
+}


### PR DESCRIPTION
I've added parameter support for this plugin.

1. Added "{{{name}}}" syntax as placeholders. This syntax will be hidden on render.
Example: `{{{1}}}`, `{{{2}}}`, `{{{some_name}}}`

2. Parameter syntax is like this:
`{{page>pagename#section&flags|param1|param2|param3...}}`
`{{page>pagename#section&flags|name1=param1|name2=param2|name3=param3...}}`

vertical bar can be escaped with backslash. like this:
`{{page>pagename|value\|with\|vertical bar|this is value 2}}`
Which resolves to:
{{{1}}} -> value|with|vertical bar
{{{2}}} -> this is value 2

When name is not provided, they will be automatically resolved as integer names - 1, 2, 3, so on.

Wiki syntax can't be used as parameter. Using parameter as link (`[[ {{{1}}} ]]') is also not possible.