### PR TITLE
Fix float on include edit button

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,6 +17,11 @@ jQuery(function() {
         .mouseout(function () {
             jQuery('.section_highlight').removeClass('section_highlight');
         });
+    
+});
+
+jQuery(document).ready(function () {
+    jQuery('.btn_incledit').closest('.plugin_include_content').after('<div style="clear:both"></div>');
 });
 
 // vim:ts=4:sw=4:et:


### PR DESCRIPTION
Before clearing the float after the include edit button:

<img width="1280" alt="SCR-20230324-kjft" src="https://user-images.githubusercontent.com/2974895/227553498-f2030d82-6fb6-478b-9515-1a2aee5ff47a.png">

After clearing the float after the include edit button:

<img width="1280" alt="SCR-20230324-kjlu" src="https://user-images.githubusercontent.com/2974895/227553517-cff93b08-299f-4cea-b354-5f94083d2c48.png">
