### PR TITLE
clear-both-missing-causes-following-caption-to-wrap

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,12 @@
+div.plugin_include_content div.tags {
+  margin-bottom: 0 !important;
+}
+
+div.plugin_include_content {
+  display: flow-root;
+  margin-bottom: 1.4em;
+}
+
 div.dokuwiki div.plugin_include_content div.secedit {
   float: right;
   margin-left: 1em;
@@ -11,7 +20,6 @@ div.dokuwiki div.inclmeta {
   font-size: 80%;
   line-height: 1.25;
   /*margin-top: 0.5em;*/
-  margin-bottom: 2em;
 }
 
 div.dokuwiki div.inclmeta a.permalink {


### PR DESCRIPTION
Especially when using `nouser` and `nodate` options, for example:

```
{{namespace>mynamespace:*&nouser&nodate}}
```

The next caption tends to line-break when it hits the predecing "edit" buttons.


This happens because the edit buttons are `float: right`.

The pull request fixes that by introducing a `<div style="clear: both">`.