### PR TITLE
Address code style issues

### DIFF
--- a/GenericResolver.php
+++ b/GenericResolver.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace dokuwiki\plugin\include;
+
 use dokuwiki\File\Resolver;
 
 /**
@@ -7,5 +9,6 @@ use dokuwiki\File\Resolver;
  *
  * @package dokuwiki\plugin\include
  */
-class GenericResolver extends Resolver {
+class GenericResolver extends Resolver
+{
 }

--- a/_test/namespace_includes.test.php
+++ b/_test/namespace_includes.test.php
@@ -66,7 +66,7 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
      */
     public function test_hidden() {
         $flags = $this->helper->get_flags(array());
-        $pages = $this->helper->_get_included_pages('namespace', 'inclhidden:', '', '', $flags);
+        $pages = $this->helper->getIncludedPages('namespace', 'inclhidden:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'inclhidden:visible', 'exists' => true, 'parent_id' => ''),
                             ), $pages);
@@ -77,24 +77,24 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
      */
     public function test_depth() {
         $flags = $this->helper->get_flags(array());
-        $pages = $this->helper->_get_included_pages('namespace', 'incltest:', '', '', $flags);
+        $pages = $this->helper->getIncludedPages('namespace', 'incltest:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'incltest:level1', 'exists' => true, 'parent_id' => ''),
                             ), $pages);
         $flags = $this->helper->get_flags(array('depth=2'));
-        $pages = $this->helper->_get_included_pages('namespace', 'incltest:', '', '', $flags);
+        $pages = $this->helper->getIncludedPages('namespace', 'incltest:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'incltest:level1', 'exists' => true, 'parent_id' => ''),
                                  array('id' => 'incltest:ns:level2', 'exists' => true, 'parent_id' => ''),
                             ), $pages);
         $flags = $this->helper->get_flags(array('depth=2'));
-        $pages = $this->helper->_get_included_pages('namespace', 'incltest:ns', '', '', $flags);
+        $pages = $this->helper->getIncludedPages('namespace', 'incltest:ns', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'incltest:ns:level2', 'exists' => true, 'parent_id' => ''),
                                  array('id' => 'incltest:ns:ns:level3', 'exists' => true, 'parent_id' => ''),
                             ), $pages);
         $flags = $this->helper->get_flags(array('depth=0'));
-        $pages = $this->helper->_get_included_pages('namespace', 'incltest:', '', '', $flags);
+        $pages = $this->helper->getIncludedPages('namespace', 'incltest:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'incltest:level1', 'exists' => true, 'parent_id' => ''),
                                  array('id' => 'incltest:ns:level2', 'exists' => true, 'parent_id' => ''),
@@ -103,10 +103,10 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
 
         // test include of the root namespace
         $flags = $this->helper->get_flags(array());
-        $pages = $this->helper->_get_included_pages('namespace', ':', '', '', $flags);
+        $pages = $this->helper->getIncludedPages('namespace', ':', '', '', $flags);
         $this->assertEquals(array(array('id' => 'mailinglist', 'exists' => true, 'parent_id' => '')), $pages);
         $flags = $this->helper->get_flags(array('depth=2'));
-        $pages = $this->helper->_get_included_pages('namespace', ':', '', '', $flags);
+        $pages = $this->helper->getIncludedPages('namespace', ':', '', '', $flags);
         $expected = array(
                                  array('id' => 'inclhidden:visible', 'exists' => true, 'parent_id' => ''),
                                  array('id' => 'inclorder:page1', 'exists' => true, 'parent_id' => ''),
@@ -144,7 +144,7 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
     public function test_order() {
 
         $flags = $this->helper->get_flags(array());
-        $pages = $this->helper->_get_included_pages('namespace', 'inclorder:', '', '', $flags);
+        $pages = $this->helper->getIncludedPages('namespace', 'inclorder:', '', '', $flags);
 
         $this->assertEquals(array(
                                  array('id' => 'inclorder:page1', 'exists' => true, 'parent_id' => ''),
@@ -154,7 +154,7 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
                             ), $pages);
 
         $flags = $this->helper->get_flags(array('rsort'));
-        $pages = $this->helper->_get_included_pages('namespace', 'inclorder:', '', '', $flags);
+        $pages = $this->helper->getIncludedPages('namespace', 'inclorder:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'inclorder:page4', 'exists' => true, 'parent_id' => ''),
                                  array('id' => 'inclorder:page3', 'exists' => true, 'parent_id' => ''),
@@ -162,7 +162,7 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
                                  array('id' => 'inclorder:page1', 'exists' => true, 'parent_id' => ''),
                             ), $pages);
         $flags = $this->helper->get_flags(array('order=custom'));
-        $pages = $this->helper->_get_included_pages('namespace', 'inclorder:', '', '', $flags);
+        $pages = $this->helper->getIncludedPages('namespace', 'inclorder:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'inclorder:page4', 'exists' => true, 'parent_id' => ''),
                                  array('id' => 'inclorder:page3', 'exists' => true, 'parent_id' => ''),
@@ -171,7 +171,7 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
                             ), $pages);
 
         $flags = $this->helper->get_flags(array('order=custom', 'rsort'));
-        $pages = $this->helper->_get_included_pages('namespace', 'inclorder:', '', '', $flags);
+        $pages = $this->helper->getIncludedPages('namespace', 'inclorder:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'inclorder:page2', 'exists' => true, 'parent_id' => ''),
                                  array('id' => 'inclorder:page1', 'exists' => true, 'parent_id' => ''),

--- a/_test/namespace_includes.test.php
+++ b/_test/namespace_includes.test.php
@@ -65,7 +65,7 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
      * Test hiding of hidden pages in namespace includes
      */
     public function test_hidden() {
-        $flags = $this->helper->get_flags(array());
+        $flags = $this->helper->getFlags(array());
         $pages = $this->helper->getIncludedPages('namespace', 'inclhidden:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'inclhidden:visible', 'exists' => true, 'parent_id' => ''),
@@ -76,24 +76,24 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
      * Test include depth limit
      */
     public function test_depth() {
-        $flags = $this->helper->get_flags(array());
+        $flags = $this->helper->getFlags(array());
         $pages = $this->helper->getIncludedPages('namespace', 'incltest:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'incltest:level1', 'exists' => true, 'parent_id' => ''),
                             ), $pages);
-        $flags = $this->helper->get_flags(array('depth=2'));
+        $flags = $this->helper->getFlags(array('depth=2'));
         $pages = $this->helper->getIncludedPages('namespace', 'incltest:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'incltest:level1', 'exists' => true, 'parent_id' => ''),
                                  array('id' => 'incltest:ns:level2', 'exists' => true, 'parent_id' => ''),
                             ), $pages);
-        $flags = $this->helper->get_flags(array('depth=2'));
+        $flags = $this->helper->getFlags(array('depth=2'));
         $pages = $this->helper->getIncludedPages('namespace', 'incltest:ns', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'incltest:ns:level2', 'exists' => true, 'parent_id' => ''),
                                  array('id' => 'incltest:ns:ns:level3', 'exists' => true, 'parent_id' => ''),
                             ), $pages);
-        $flags = $this->helper->get_flags(array('depth=0'));
+        $flags = $this->helper->getFlags(array('depth=0'));
         $pages = $this->helper->getIncludedPages('namespace', 'incltest:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'incltest:level1', 'exists' => true, 'parent_id' => ''),
@@ -102,10 +102,10 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
                             ), $pages);
 
         // test include of the root namespace
-        $flags = $this->helper->get_flags(array());
+        $flags = $this->helper->getFlags(array());
         $pages = $this->helper->getIncludedPages('namespace', ':', '', '', $flags);
         $this->assertEquals(array(array('id' => 'mailinglist', 'exists' => true, 'parent_id' => '')), $pages);
-        $flags = $this->helper->get_flags(array('depth=2'));
+        $flags = $this->helper->getFlags(array('depth=2'));
         $pages = $this->helper->getIncludedPages('namespace', ':', '', '', $flags);
         $expected = array(
                                  array('id' => 'inclhidden:visible', 'exists' => true, 'parent_id' => ''),
@@ -143,7 +143,7 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
      */
     public function test_order() {
 
-        $flags = $this->helper->get_flags(array());
+        $flags = $this->helper->getFlags(array());
         $pages = $this->helper->getIncludedPages('namespace', 'inclorder:', '', '', $flags);
 
         $this->assertEquals(array(
@@ -153,7 +153,7 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
                                  array('id' => 'inclorder:page4', 'exists' => true, 'parent_id' => ''),
                             ), $pages);
 
-        $flags = $this->helper->get_flags(array('rsort'));
+        $flags = $this->helper->getFlags(array('rsort'));
         $pages = $this->helper->getIncludedPages('namespace', 'inclorder:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'inclorder:page4', 'exists' => true, 'parent_id' => ''),
@@ -161,7 +161,7 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
                                  array('id' => 'inclorder:page2', 'exists' => true, 'parent_id' => ''),
                                  array('id' => 'inclorder:page1', 'exists' => true, 'parent_id' => ''),
                             ), $pages);
-        $flags = $this->helper->get_flags(array('order=custom'));
+        $flags = $this->helper->getFlags(array('order=custom'));
         $pages = $this->helper->getIncludedPages('namespace', 'inclorder:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'inclorder:page4', 'exists' => true, 'parent_id' => ''),
@@ -170,7 +170,7 @@ class plugin_include_namespaces_includes_test extends DokuWikiTest {
                                  array('id' => 'inclorder:page2', 'exists' => true, 'parent_id' => ''),
                             ), $pages);
 
-        $flags = $this->helper->get_flags(array('order=custom', 'rsort'));
+        $flags = $this->helper->getFlags(array('order=custom', 'rsort'));
         $pages = $this->helper->getIncludedPages('namespace', 'inclorder:', '', '', $flags);
         $this->assertEquals(array(
                                  array('id' => 'inclorder:page2', 'exists' => true, 'parent_id' => ''),

--- a/action.php
+++ b/action.php
@@ -50,7 +50,7 @@ class action_plugin_include extends ActionPlugin
      * Add a version string to the index so it is rebuilt
      * whenever the handler is updated or the safeindex setting is changed
      */
-    public function handleIndexerVersion($event, $param)
+    public function handleIndexerVersion(Event $event, $param)
     {
         $event->data['plugin_include'] = '0.1.safeindex=' . $this->getConf('safeindex');
     }
@@ -136,7 +136,7 @@ class action_plugin_include extends ActionPlugin
     /**
      * Used for debugging purposes only
      */
-    public function handleMetadata(&$event, $param)
+    public function handleMetadata(Event $event, $param)
     {
         global $conf;
         if ($conf['allowdebug'] && $this->getConf('debugoutput')) {
@@ -191,7 +191,7 @@ class action_plugin_include extends ActionPlugin
     /**
      * Modify the data for the redirect when there is a redirect_id set
      */
-    public function handleRedirect(Event &$event, $param)
+    public function handleRedirect(Event $event, $param)
     {
         if (array_key_exists('redirect_id', $_REQUEST)) {
             // Render metadata when this is an older DokuWiki version where
@@ -209,7 +209,7 @@ class action_plugin_include extends ActionPlugin
     /**
      * prepare the cache object for default _useCache action
      */
-    public function handleCachePrepare(Event &$event, $param)
+    public function handleCachePrepare(Event $event, $param)
     {
         global $conf;
 
@@ -264,7 +264,7 @@ class action_plugin_include extends ActionPlugin
      * and replace normal section edit buttons when the current page is different from the
      * global $ID.
      */
-    public function handleSeceditButton(Event &$event, $params)
+    public function handleSeceditButton(Event $event, $params)
     {
         // stack of included pages in the form ('id' => page, 'rev' => modification time, 'writable' => bool)
         static $page_stack = [];

--- a/action.php
+++ b/action.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Include Plugin:  Display a wiki page within another wiki page
  *
@@ -13,23 +14,25 @@
  * All DokuWiki plugins to extend the parser/rendering mechanism
  * need to inherit from this class
  */
-class action_plugin_include extends DokuWiki_Action_Plugin {
-
+class action_plugin_include extends DokuWiki_Action_Plugin
+{
     /* @var helper_plugin_include $helper */
     var $helper = null;
 
-    function __construct() {
+    function __construct()
+    {
         $this->helper = plugin_load('helper', 'include');
     }
 
     /**
      * plugin should use this method to register its handlers with the dokuwiki's event controller
      */
-    function register(Doku_Event_Handler $controller) {
+    function register(Doku_Event_Handler $controller)
+    {
         /* @var Doku_event_handler $controller */
         $controller->register_hook('INDEXER_PAGE_ADD', 'BEFORE', $this, 'handle_indexer');
         $controller->register_hook('INDEXER_VERSION_GET', 'BEFORE', $this, 'handle_indexer_version');
-        $controller->register_hook('PARSER_CACHE_USE','BEFORE', $this, '_cache_prepare');
+        $controller->register_hook('PARSER_CACHE_USE', 'BEFORE', $this, '_cache_prepare');
         $controller->register_hook('HTML_EDITFORM_OUTPUT', 'BEFORE', $this, 'handle_form'); // todo remove
         $controller->register_hook('FORM_EDIT_OUTPUT', 'BEFORE', $this, 'handle_form');
         $controller->register_hook('HTML_CONFLICTFORM_OUTPUT', 'BEFORE', $this, 'handle_form'); // todo remove
@@ -47,8 +50,9 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
      * Add a version string to the index so it is rebuilt
      * whenever the handler is updated or the safeindex setting is changed
      */
-    public function handle_indexer_version($event, $param) {
-        $event->data['plugin_include'] = '0.1.safeindex='.$this->getConf('safeindex');
+    public function handle_indexer_version($event, $param)
+    {
+        $event->data['plugin_include'] = '0.1.safeindex=' . $this->getConf('safeindex');
     }
 
     /**
@@ -57,7 +61,8 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
      * @param Doku_Event $event  the event object
      * @param array      $params optional parameters (unused)
      */
-    public function handle_indexer(Doku_Event $event, $params) {
+    public function handle_indexer(Doku_Event $event, $params)
+    {
         global $USERINFO;
 
         // check if the feature is enabled at all
@@ -111,7 +116,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
             if ($tag_called) {
                 $tag_helper = $this->loadHelper('tag', false);
                 if ($tag_helper) {
-                    if (isset($meta['subject']))  {
+                    if (isset($meta['subject'])) {
                         $event->data['metadata']['subject'] = $tag_helper->_cleanTagList($meta['subject']);
                     } else {
                         $event->data['metadata']['subject'] = array();
@@ -128,9 +133,10 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
     /**
      * Used for debugging purposes only
      */
-    function handle_metadata(&$event, $param) {
+    function handle_metadata(&$event, $param)
+    {
         global $conf;
-        if($conf['allowdebug'] && $this->getConf('debugoutput')) {
+        if ($conf['allowdebug'] && $this->getConf('debugoutput')) {
             dbglog('---- PLUGIN INCLUDE META DATA START ----');
             dbglog($event->data);
             dbglog('---- PLUGIN INCLUDE META DATA END ----');
@@ -143,31 +149,32 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
      * @author Michael Klier <chi@chimeric.de>
      * @author Michael Hamann <michael@content-space.de>
      */
-    function handle_parser(Doku_Event $event, $param) {
+    function handle_parser(Doku_Event $event, $param)
+    {
         global $ID;
 
         $level = 0;
         $ins =& $event->data->calls;
         $num = count($ins);
-        for($i=0; $i<$num; $i++) {
-            switch($ins[$i][0]) {
-            case 'plugin':
-                switch($ins[$i][1][0]) {
-                case 'include_include':
-                    $ins[$i][1][1][4] = $level;
-                    break;
+        for ($i = 0; $i < $num; $i++) {
+            switch ($ins[$i][0]) {
+                case 'plugin':
+                    switch ($ins[$i][1][0]) {
+                        case 'include_include':
+                            $ins[$i][1][1][4] = $level;
+                            break;
                     /* FIXME: this doesn't work anymore that way with the new structure
                     // some plugins already close open sections
                     // so we need to make sure we don't close them twice
-                case 'box':
+                    case 'box':
                     $this->helper->sec_close = false;
                     break;
                      */
-                }
-                break;
-            case 'section_open':
-                $level = $ins[$i][1][0];
-                break;
+                    }
+                    break;
+                case 'section_open':
+                    $level = $ins[$i][1][0];
+                    break;
             }
         }
     }
@@ -179,7 +186,7 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
     {
         if (!array_key_exists('redirect_id', $_REQUEST)) return;
 
-        if(is_a($event->data, \dokuwiki\Form\Form::class)) {
+        if (is_a($event->data, \dokuwiki\Form\Form::class)) {
             $event->data->setHiddenField('redirect_id', cleanID($_REQUEST['redirect_id']));
         } else {
             // todo remove when old FORM events are no longer supported
@@ -190,35 +197,37 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
     /**
      * Modify the data for the redirect when there is a redirect_id set
      */
-    function handle_redirect(Doku_Event &$event, $param) {
-      if (array_key_exists('redirect_id', $_REQUEST)) {
-        // Render metadata when this is an older DokuWiki version where
-        // metadata is not automatically re-rendered as the page has probably
-        // been changed but is not directly displayed
-        $versionData = getVersionData();
-        if ($versionData['date'] < '2010-11-23') {
-            p_set_metadata($event->data['id'], array(), true);
+    function handle_redirect(Doku_Event &$event, $param)
+    {
+        if (array_key_exists('redirect_id', $_REQUEST)) {
+          // Render metadata when this is an older DokuWiki version where
+          // metadata is not automatically re-rendered as the page has probably
+          // been changed but is not directly displayed
+            $versionData = getVersionData();
+            if ($versionData['date'] < '2010-11-23') {
+                p_set_metadata($event->data['id'], array(), true);
+            }
+            $event->data['id'] = cleanID($_REQUEST['redirect_id']);
+            $event->data['title'] = '';
         }
-        $event->data['id'] = cleanID($_REQUEST['redirect_id']);
-        $event->data['title'] = '';
-      }
     }
 
     /**
      * prepare the cache object for default _useCache action
      */
-    function _cache_prepare(Doku_Event &$event, $param) {
+    function _cache_prepare(Doku_Event &$event, $param)
+    {
         global $conf;
 
         /* @var cache_renderer $cache */
         $cache =& $event->data;
 
-        if(!isset($cache->page)) return;
-        if(!isset($cache->mode) || $cache->mode == 'i') return;
+        if (!isset($cache->page)) return;
+        if (!isset($cache->mode) || $cache->mode == 'i') return;
 
         $depends = p_get_metadata($cache->page, 'plugin_include');
 
-        if($conf['allowdebug'] && $this->getConf('debugoutput')) {
+        if ($conf['allowdebug'] && $this->getConf('debugoutput')) {
             dbglog('---- PLUGIN INCLUDE CACHE DEPENDS START ----');
             dbglog($depends);
             dbglog('---- PLUGIN INCLUDE CACHE DEPENDS END ----');
@@ -226,14 +235,15 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
 
         if (!is_array($depends)) return; // nothing to do for us
 
-        if (!is_array($depends['pages']) ||
+        if (
+            !is_array($depends['pages']) ||
             !is_array($depends['instructions']) ||
             $depends['pages'] != $this->helper->_get_included_pages_from_meta_instructions($depends['instructions']) ||
             // the include_content url parameter may change the behavior for included pages
-            $depends['include_content'] != isset($_REQUEST['include_content'])) {
-
+            $depends['include_content'] != isset($_REQUEST['include_content'])
+        ) {
             $cache->depends['purge'] = true; // included pages changed or old metadata - request purge.
-            if($conf['allowdebug'] && $this->getConf('debugoutput')) {
+            if ($conf['allowdebug'] && $this->getConf('debugoutput')) {
                 dbglog('---- PLUGIN INCLUDE: REQUESTING CACHE PURGE ----');
                 dbglog('---- PLUGIN INCLUDE CACHE PAGES FROM META START ----');
                 dbglog($depends['pages']);
@@ -241,7 +251,6 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
                 dbglog('---- PLUGIN INCLUDE CACHE PAGES FROM META_INSTRUCTIONS START ----');
                 dbglog($this->helper->_get_included_pages_from_meta_instructions($depends['instructions']));
                 dbglog('---- PLUGIN INCLUDE CACHE PAGES FROM META_INSTRUCTIONS END ----');
-
             }
         } else {
             // add plugin.info.txt to depends for nicer upgrades
@@ -261,7 +270,8 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
      * and replace normal section edit buttons when the current page is different from the
      * global $ID.
      */
-    function handle_secedit_button(Doku_Event &$event, $params) {
+    function handle_secedit_button(Doku_Event &$event, $params)
+    {
         // stack of included pages in the form ('id' => page, 'rev' => modification time, 'writable' => bool)
         static $page_stack = array();
 
@@ -290,14 +300,18 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
                     $params['hid'] = $data['hid'];
                 }
                 $event->result = '<div class="secedit">' . DOKU_LF .
-                    html_btn('incledit', $page_stack[0]['id'], '',
-                        $params, 'post',
+                    html_btn(
+                        'incledit',
+                        $page_stack[0]['id'],
+                        '',
+                        $params,
+                        'post',
                         $data['name'],
-                        $lang['btn_secedit'].' ('.$page_stack[0]['id'].')') .
+                        $lang['btn_secedit'] . ' (' . $page_stack[0]['id'] . ')'
+                    ) .
                     '</div>' . DOKU_LF;
             }
         } elseif (!empty($page_stack)) {
-
             // Special handling for the edittable plugin
             if ($data['target'] == 'table' && !plugin_isdisabled('edittable')) {
                 /* @var action_plugin_edittable_editor $edittable */
@@ -319,11 +333,16 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
 
                 $event->result = "<div class='secedit editbutton_" . $data['target'] .
                     " editbutton_" . $secid . "'>" .
-                    html_btn('secedit', $page_stack[0]['id'], '',
+                    html_btn(
+                        'secedit',
+                        $page_stack[0]['id'],
+                        '',
                         array_merge(array('do'  => 'edit',
                         'rev' => $page_stack[0]['rev'],
-                        'summary' => '['.$name.'] '), $data),
-                        'post', $name) . '</div>';
+                        'summary' => '[' . $name . '] '), $data),
+                        'post',
+                        $name
+                    ) . '</div>';
             } else {
                 $event->result = '';
             }
@@ -335,11 +354,13 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
         $event->stopPropagation();
     }
 
-    public function handle_move_register(Doku_Event $event, $params) {
+    public function handle_move_register(Doku_Event $event, $params)
+    {
         $event->data['handlers']['include_include'] = array($this, 'rewrite_include');
     }
 
-    public function rewrite_include($match, $pos, $state, $plugin, helper_plugin_move_handler $handler) {
+    public function rewrite_include($match, $pos, $state, $plugin, helper_plugin_move_handler $handler)
+    {
         $syntax = substr($match, 2, -2); // strip markup
         $replacers = explode('|', $syntax);
         $syntax = array_shift($replacers);
@@ -358,10 +379,10 @@ class action_plugin_include extends DokuWiki_Action_Plugin {
         if ($newpage == $page) {
             return $match;
         } else {
-            $result = '{{'.$mode.'>'.$newpage;
-            if ($sect) $result .= '#'.$sect;
-            if ($flags) $result .= '&'.$flags;
-            if ($replacers) $result .= '|'.$replacers;
+            $result = '{{' . $mode . '>' . $newpage;
+            if ($sect) $result .= '#' . $sect;
+            if ($flags) $result .= '&' . $flags;
+            if ($replacers) $result .= '|' . $replacers;
             $result .= '}}';
             return $result;
         }

--- a/action.php
+++ b/action.php
@@ -196,15 +196,10 @@ class action_plugin_include extends ActionPlugin
      */
     public function handleRedirect(Event $event, $param)
     {
-        if (array_key_exists('redirect_id', $_REQUEST)) {
-            // Render metadata when this is an older DokuWiki version where
-            // metadata is not automatically re-rendered as the page has probably
-            // been changed but is not directly displayed
-            $versionData = getVersionData();
-            if ($versionData['date'] < '2010-11-23') {
-                p_set_metadata($event->data['id'], [], true);
-            }
-            $event->data['id'] = cleanID($_REQUEST['redirect_id']);
+        global $INPUT;
+
+        if ($INPUT->has('redirect_id')) {
+            $event->data['id'] = cleanID($INPUT->str('redirect_id'));
             $event->data['title'] = '';
         }
     }

--- a/action.php
+++ b/action.php
@@ -121,7 +121,7 @@ class action_plugin_include extends ActionPlugin
                 $tag_helper = $this->loadHelper('tag', false);
                 if ($tag_helper) {
                     if (isset($meta['subject'])) {
-                        $event->data['metadata']['subject'] = $tag_helper->_cleanTagList($meta['subject']);
+                        $event->data['metadata']['subject'] = $tag_helper->cleanTagList($meta['subject']);
                     } else {
                         $event->data['metadata']['subject'] = [];
                     }

--- a/action.php
+++ b/action.php
@@ -17,7 +17,7 @@ use dokuwiki\Logger;
  */
 class action_plugin_include extends ActionPlugin
 {
-    /* @var helper_plugin_include $helper */
+    /** @var helper_plugin_include $helper */
     public $helper;
 
     /**
@@ -118,6 +118,7 @@ class action_plugin_include extends ActionPlugin
 
             // restore the tag metadata if the tag plugin handler has been called before the include plugin handler.
             if ($tag_called) {
+                /** @var helper_plugin_tag $tag_helper */
                 $tag_helper = $this->loadHelper('tag', false);
                 if ($tag_helper) {
                     if (isset($meta['subject'])) {

--- a/action.php
+++ b/action.php
@@ -141,10 +141,11 @@ class action_plugin_include extends ActionPlugin
     public function handleMetadata(Event $event, $param)
     {
         global $conf;
-        if ($conf['allowdebug'] && $this->getConf('debugoutput')) {
-            dbglog('---- PLUGIN INCLUDE META DATA START ----');
-            dbglog($event->data);
-            dbglog('---- PLUGIN INCLUDE META DATA END ----');
+        if ($this->getConf('debugoutput')) {
+            Logger::debug(
+                'include plugin: metadata rendered for page ' . $event->data['page'],
+                $event->data
+            );
         }
     }
 

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,7 +1,9 @@
 <?php
+
 /**
  * Options for the Include Plugin
  */
+
 $conf['noheader']      = 0;      // Don't display the header of the inserted section
 $conf['firstseconly']  = 0;      // limit entries on main blog page to first section
 $conf['showtaglogos']  = 0;      // display image for first tag

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,10 +1,12 @@
 <?php
+
 /**
  * Metadata for configuration manager plugin
  * Additions for the Include Plugin
  *
  * @author    Esther Brunner <wikidesign@gmail.com>
  */
+
 $meta['noheader']      = array('onoff');
 $meta['firstseconly']  = array('onoff');
 $meta['showtaglogos']  = array('onoff');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -27,7 +27,10 @@ $meta['title']         = array('onoff');
 $meta['pageexists']    = array('onoff');
 $meta['parlink']       = array('onoff');
 $meta['safeindex']     = array('onoff');
-$meta['order']         = array('multichoice', '_choices' => array('id', 'title', 'created', 'modified', 'indexmenu', 'custom'));
+$meta['order']         = array(
+    'multichoice',
+    '_choices' => array('id', 'title', 'created', 'modified', 'indexmenu', 'custom')
+);
 $meta['rsort']         = array('onoff');
 $meta['depth']         = array('numeric', '_min' => 0);
 $meta['readmore']      = array('onoff');

--- a/helper.php
+++ b/helper.php
@@ -255,7 +255,7 @@ class helper_plugin_include extends Plugin
     /**
      * Returns the converted instructions of a give page/section
      */
-    protected function getInstructions($page, $sect, $mode, $lvl, $flags, $root_id = null, $included_pages = [])
+    public function getInstructions($page, $sect, $mode, $lvl, $flags, $root_id = null, $included_pages = [])
     {
         $key = ($sect) ? $page . '#' . $sect : $page;
         $this->includes[$key] = true; // legacy code for keeping compatibility with other plugins
@@ -871,7 +871,7 @@ class helper_plugin_include extends Plugin
      * This function generates the list of all included pages from a list of metadata
      * instructions.
      */
-    protected function getIncludedPagesFromMetaInstructions($instructions)
+    public function getIncludedPagesFromMetaInstructions($instructions)
     {
         $pages = [];
         foreach ($instructions as $instruction) {

--- a/helper.php
+++ b/helper.php
@@ -71,14 +71,41 @@ class helper_plugin_include extends Plugin
     }
 
     /**
-     * This is not a PSR-2 compliant method name
-     * @deprecated 2025-07-04
+     * Magic method to handle deprecated method calls
      *
+     * @param string $func The name of the method being called
+     * @param array $args The arguments passed to the method
+     * @return mixed
      */
-    public function get_flags($setflags) // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+    public function __call($func, $args)
     {
-        dbg_deprecated('getFlags()');
-        return $this->getFlags($setflags);
+        switch ($func) {
+            case 'get_flags':
+                dbg_deprecated('getFlags()');
+                return $this->getFlags($args[0]);
+            case '_get_instructions':
+                dbg_deprecated('getInstructions()');
+                return $this->getInstructions(
+                    $args[0], // page
+                    $args[1], // sect
+                    $args[2], // mode
+                    $args[3], // lvl
+                    $args[4], // flags
+                    $args[5] ?? null, // root_id
+                    $args[6] ?? [] // included_pages
+                );
+            case '_get_included_pages':
+                dbg_deprecated('getIncludedPages()');
+                return $this->getIncludedPages(
+                    $args[0], // mode
+                    $args[1], // page
+                    $args[2], // sect
+                    $args[3], // parent_id
+                    $args[4]  // flags
+                );
+            default:
+                throw new \BadMethodCallException("Method $func does not exist in " . __CLASS__);
+        }
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Esther Brunner <wikidesign@gmail.com>
@@ -6,13 +7,16 @@
  * @author     Gina Häußge, Michael Klier <dokuwiki@chimeric.de>
  * @author     Michael Hamann <michael@content-space.de>
  */
+
 use dokuwiki\plugin\include\GenericResolver;
 use dokuwiki\File\PageResolver;
 
 /**
  * Helper functions for the include plugin and other plugins that want to include pages.
  */
-class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
+class helper_plugin_include extends DokuWiki_Plugin
+{
+ // DokuWiki_Helper_Plugin
 
     var $defaults  = array();
     var $sec_close = true;
@@ -23,7 +27,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
     /**
      * Constructor loads default config settings once
      */
-    function __construct() {
+    function __construct()
+    {
         $this->defaults['noheader']  = $this->getConf('noheader');
         $this->defaults['firstsec']  = $this->getConf('firstseconly');
         $this->defaults['editbtn']   = $this->getConf('showeditbtn');
@@ -53,7 +58,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
     /**
      * Available methods for other plugins
      */
-    function getMethods() {
+    function getMethods()
+    {
         $result = array();
         $result[] = array(
                 'name'   => 'get_flags',
@@ -66,7 +72,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
     /**
      * Overrides standard values for showfooter and firstseconly settings
      */
-    function get_flags($setflags) {
+    function get_flags($setflags)
+    {
         // load defaults
         $flags = $this->defaults;
         foreach ($setflags as $flag) {
@@ -236,7 +243,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      * @author Michael Klier <chi@chimeric.de>
      * @author Michael Hamann <michael@content-space.de>
      */
-    function _get_instructions($page, $sect, $mode, $lvl, $flags, $root_id = null, $included_pages = array()) {
+    function _get_instructions($page, $sect, $mode, $lvl, $flags, $root_id = null, $included_pages = array())
+    {
         $key = ($sect) ? $page . '#' . $sect : $page;
         $this->includes[$key] = true; // legacy code for keeping compatibility with other plugins
 
@@ -251,16 +259,16 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 $title = '';
                 if ($flags['title'])
                     $title = p_get_first_heading($page);
-                if($flags['parlink']) {
+                if ($flags['parlink']) {
                     $ins = array(
                         array('p_open', array()),
-                        array('internallink', array(':'.$key, $title)),
+                        array('internallink', array(':' . $key, $title)),
                         array('p_close', array()),
                     );
                 } else {
-                    $ins = array(array('internallink', array(':'.$key,$title)));
+                    $ins = array(array('internallink', array(':' . $key,$title)));
                 }
-            }else {
+            } else {
                 $ins = array();
             }
         } else {
@@ -292,15 +300,16 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function _convert_instructions(&$ins, $lvl, $page, $sect, $flags, $root_id, $included_pages = array()) {
+    function _convert_instructions(&$ins, $lvl, $page, $sect, $flags, $root_id, $included_pages = array())
+    {
         global $conf;
 
         // filter instructions if needed
-        if(!empty($sect)) {
+        if (!empty($sect)) {
             $this->_get_section($ins, $sect);   // section required
         }
 
-        if($flags['firstsec']) {
+        if ($flags['firstsec']) {
             $this->_get_firstsec($ins, $page, $flags);  // only first section
         }
 
@@ -315,8 +324,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
 
         $this->adapt_links($ins, $page, $included_pages);
 
-        for($i=0; $i<$num; $i++) {
-            switch($ins[$i][0]) {
+        for ($i = 0; $i < $num; $i++) {
+            switch ($ins[$i][0]) {
                 case 'document_start':
                 case 'document_end':
                 case 'section_edit':
@@ -324,27 +333,26 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                     break;
                 case 'header':
                     // get section title of first section
-                    if($sect && !$sect_title) {
+                    if ($sect && !$sect_title) {
                         $sect_title = $ins[$i][1][0];
                     }
                     // check if we need to skip the first header
-                    if((!$no_header) && $flags['noheader']) {
+                    if ((!$no_header) && $flags['noheader']) {
                         $no_header = true;
                     }
 
                     $conv_idx[] = $i;
                     // get index of first header
-                    if($first_header == -1) $first_header = $i;
+                    if ($first_header == -1) $first_header = $i;
                     // get max level of this instructions set
-                    if(!$lvl_max || ($ins[$i][1][1] < $lvl_max)) {
+                    if (!$lvl_max || ($ins[$i][1][1] < $lvl_max)) {
                         $lvl_max = $ins[$i][1][1];
                     }
                     break;
                 case 'section_open':
                     if ($flags['inline'])
                         unset($ins[$i]);
-                    else
-                        $conv_idx[] = $i;
+                    else $conv_idx[] = $i;
                     break;
                 case 'section_close':
                     if ($flags['inline'])
@@ -355,7 +363,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                     break;
                 case 'plugin':
                     // FIXME skip other plugins?
-                    switch($ins[$i][1][0]) {
+                    switch ($ins[$i][1][0]) {
                         case 'tag_tag':                 // skip tags
                         case 'discussion_comments':     // skip comments
                         case 'linkback':                // skip linkbacks
@@ -399,37 +407,37 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
         $footer_lvl       = false;
         $contains_secedit = false;
         $section_close_at = false;
-        foreach($conv_idx as $idx) {
-            if($ins[$idx][0] == 'header') {
-                if ($section_close_at === false && isset($ins[$idx+1]) && $ins[$idx+1][0] == 'section_open') {
+        foreach ($conv_idx as $idx) {
+            if ($ins[$idx][0] == 'header') {
+                if ($section_close_at === false && isset($ins[$idx + 1]) && $ins[$idx + 1][0] == 'section_open') {
                     // store the index of the first heading that is followed by a new section
                     // the wrap plugin creates sections without section_open so the section shouldn't be closed before them
                     $section_close_at = $idx;
                 }
 
-                if($no_header && !$hdr_deleted) {
-                    unset ($ins[$idx]);
+                if ($no_header && !$hdr_deleted) {
+                    unset($ins[$idx]);
                     $hdr_deleted = true;
                     continue;
                 }
 
-                if($flags['indent']) {
+                if ($flags['indent']) {
                     $lvl_new = (($ins[$idx][1][1] + $diff) > 5) ? 5 : ($ins[$idx][1][1] + $diff);
                     $ins[$idx][1][1] = $lvl_new;
                 }
 
-                if($ins[$idx][1][1] <= $conf['maxseclevel'])
+                if ($ins[$idx][1][1] <= $conf['maxseclevel'])
                     $contains_secedit = true;
 
                 // set permalink
-                if($flags['link'] && !$has_permalink && ($idx == $first_header)) {
+                if ($flags['link'] && !$has_permalink && ($idx == $first_header)) {
                     $this->_permalink($ins[$idx], $page, $sect, $flags);
                     $has_permalink = true;
                 }
 
                 // set footer level
-                if(!$footer_lvl && ($idx == $first_header) && !$no_header) {
-                    if($flags['indent'] && isset($lvl_new)) {
+                if (!$footer_lvl && ($idx == $first_header) && !$no_header) {
+                    if ($flags['indent'] && isset($lvl_new)) {
                         $footer_lvl = $lvl_new;
                     } else {
                         $footer_lvl = $lvl_max;
@@ -437,14 +445,14 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 }
             } else {
                 // it's a section
-                if($flags['indent']) {
+                if ($flags['indent']) {
                     $lvl_new = (($ins[$idx][1][0] + $diff) > 5) ? 5 : ($ins[$idx][1][0] + $diff);
                     $ins[$idx][1][0] = $lvl_new;
                 }
 
                 // check if noheader is used and set the footer level to the first section
-                if($no_header && !$footer_lvl) {
-                    if($flags['indent'] && isset($lvl_new)) {
+                if ($no_header && !$footer_lvl) {
+                    if ($flags['indent'] && isset($lvl_new)) {
                         $footer_lvl = $lvl_new;
                     } else {
                         $footer_lvl = $lvl_max;
@@ -458,15 +466,15 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
             array_push($ins, array('plugin', array('include_closelastsecedit', array($endpos))));
         }
 
-        $include_secid = (isset($flags['include_secid']) ? $flags['include_secid'] : NULL);
+        $include_secid = (isset($flags['include_secid']) ? $flags['include_secid'] : null);
 
         // add edit button
-        if($flags['editbtn']) {
+        if ($flags['editbtn']) {
             $this->_editbtn($ins, $page, $sect, $sect_title, ($flags['redirect'] ? $root_id : false), $include_secid);
         }
 
         // add footer
-        if($flags['footer']) {
+        if ($flags['footer']) {
             $ins[] = $this->_footer($page, $sect, $sect_title, $flags, $footer_lvl, $root_id);
         }
 
@@ -495,7 +503,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
             array_push($ins, array('entity', array($flags['aftereach'])));
 
         // close previous section if any and re-open after inclusion
-        if($lvl != 0 && $this->sec_close && !$flags['inline']) {
+        if ($lvl != 0 && $this->sec_close && !$flags['inline']) {
             array_unshift($ins, array('section_close', array()));
             $ins[] = array('section_open', array($lvl));
         }
@@ -506,7 +514,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function _footer($page, $sect, $sect_title, $flags, $footer_lvl, $root_id) {
+    function _footer($page, $sect, $sect_title, $flags, $footer_lvl, $root_id)
+    {
         $footer = array();
         $footer[0] = 'plugin';
         $footer[1] = array('include_footer', array($page, $sect, $sect_title, $flags, $root_id, $footer_lvl));
@@ -518,7 +527,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function _editbtn(&$ins, $page, $sect, $sect_title, $root_id, $hid = '') {
+    function _editbtn(&$ins, $page, $sect, $sect_title, $root_id, $hid = '')
+    {
         $title = ($sect) ? $sect_title : $page;
         $editbtn = array();
         $editbtn[0] = 'plugin';
@@ -531,7 +541,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function _permalink(&$ins, $page, $sect, $flags) {
+    function _permalink(&$ins, $page, $sect, $flags)
+    {
         $ins[0] = 'plugin';
         $ins[1] = array('include_header', array($ins[1][0], $ins[1][1], $ins[1][2], $page, $sect, $flags));
     }
@@ -543,19 +554,20 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      * @param string $page           The included page
      * @param array  $included_pages The array of pages that are included
      */
-    private function adapt_links(&$ins, $page, $included_pages = null) {
+    private function adapt_links(&$ins, $page, $included_pages = null)
+    {
         $num = count($ins);
 
-        for($i=0; $i<$num; $i++) {
+        for ($i = 0; $i < $num; $i++) {
             // adjust links with image titles
             if (strpos($ins[$i][0], 'link') !== false && isset($ins[$i][1][1]) && is_array($ins[$i][1][1]) && $ins[$i][1][1]['type'] == 'internalmedia') {
                 // resolve relative ids, but without cleaning in order to preserve the name
                 $media_id = (new GenericResolver($page))->resolveId($ins[$i][1][1]['src']);
                 // make sure that after resolving the link again it will be the same link
-                if ($media_id[0] != ':') $media_id = ':'.$media_id;
+                if ($media_id[0] != ':') $media_id = ':' . $media_id;
                 $ins[$i][1][1]['src'] = $media_id;
             }
-            switch($ins[$i][0]) {
+            switch ($ins[$i][0]) {
                 case 'internallink':
                 case 'internalmedia':
                     // make sure parameters aren't touched
@@ -569,9 +581,9 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                     // resolve the id without cleaning it
                     $link_id = (new GenericResolver($page))->resolveId($link_id);
                     // this id is internal (i.e. absolute) now, add ':' to make resolve_id work again
-                    if ($link_id[0] != ':') $link_id = ':'.$link_id;
+                    if ($link_id[0] != ':') $link_id = ':' . $link_id;
                     // restore parameters
-                    $ins[$i][1][0] = ($link_params != '') ? $link_id.'?'.$link_params : $link_id;
+                    $ins[$i][1][0] = ($link_params != '') ? $link_id . '?' . $link_params : $link_id;
 
                     if ($ins[$i][0] == 'internallink' && !empty($included_pages)) {
                         // change links to included pages into local links
@@ -605,7 +617,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                     /* Convert local links to internal links if the page hasn't been fully included */
                     if ($included_pages == null || !array_key_exists($page, $included_pages)) {
                         $ins[$i][0] = 'internallink';
-                        $ins[$i][1][0] = ':'.$page.'#'.$ins[$i][1][0];
+                        $ins[$i][1][0] = ':' . $page . '#' . $ins[$i][1][0];
                     }
                     break;
             }
@@ -617,7 +629,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function _get_section(&$ins, $sect) {
+    function _get_section(&$ins, $sect)
+    {
         $num = count($ins);
         $offset = false;
         $lvl    = false;
@@ -626,9 +639,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
 
         $check = array(); // used for sectionID() in order to get the same ids as the xhtml renderer
 
-        for($i=0; $i<$num; $i++) {
+        for ($i = 0; $i < $num; $i++) {
             if ($ins[$i][0] == 'header') {
-
                 // found the right header
                 if (sectionID($ins[$i][1][0], $check) == $sect) {
                     $offset = $i;
@@ -642,7 +654,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
         }
         $offset = $offset ? $offset : 0;
         $end = $end ? $end : ($num - 1);
-        if(is_array($ins)) {
+        if (is_array($ins)) {
             $ins = array_slice($ins, $offset, $end);
             // store the end position in the include_closelastsecedit instruction so it can generate a matching button
             $ins[] = array('plugin', array('include_closelastsecedit', array($endpos)));
@@ -654,12 +666,13 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function _get_firstsec(&$ins, $page, $flags) {
+    function _get_firstsec(&$ins, $page, $flags)
+    {
         $num = count($ins);
         $first_sect = false;
         $endpos = null; // end position in the input text
-        for($i=0; $i<$num; $i++) {
-            if($ins[$i][0] == 'section_close') {
+        for ($i = 0; $i < $num; $i++) {
+            if ($ins[$i][0] == 'section_close') {
                 $first_sect = $i;
             }
             if ($ins[$i][0] == 'header') {
@@ -673,7 +686,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
             }
             // only truncate the content and add the read more link when there is really
             // more than that first section
-            if(($first_sect) && ($ins[$i][0] == 'section_open')) {
+            if (($first_sect) && ($ins[$i][0] == 'section_open')) {
                 $ins = array_slice($ins, 0, $first_sect);
                 if ($flags['readmore']) {
                     $ins[] = array('plugin', array('include_readmore', array($page)));
@@ -691,50 +704,51 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      *
      * @author Michael Hamann <michael@content-space.de>
      */
-    function _get_included_pages($mode, $page, $sect, $parent_id, $flags) {
+    function _get_included_pages($mode, $page, $sect, $parent_id, $flags)
+    {
         global $conf;
         $pages = array();
-        switch($mode) {
-        case 'namespace':
-            $page  = cleanID($page);
-            $ns    = utf8_encodeFN(str_replace(':', '/', $page));
-            // depth is absolute depth, not relative depth, but 0 has a special meaning.
-            $depth = $flags['depth'] ? $flags['depth'] + substr_count($page, ':') + ($page ? 1 : 0) : 0;
-            search($pagearrays, $conf['datadir'], 'search_allpages', array('depth' => $depth, 'skipacl' => false), $ns);
-            if (is_array($pagearrays)) {
-                foreach ($pagearrays as $pagearray) {
-                    if (!isHiddenPage($pagearray['id'])) // skip hidden pages
+        switch ($mode) {
+            case 'namespace':
+                $page  = cleanID($page);
+                $ns    = utf8_encodeFN(str_replace(':', '/', $page));
+                // depth is absolute depth, not relative depth, but 0 has a special meaning.
+                $depth = $flags['depth'] ? $flags['depth'] + substr_count($page, ':') + ($page ? 1 : 0) : 0;
+                search($pagearrays, $conf['datadir'], 'search_allpages', array('depth' => $depth, 'skipacl' => false), $ns);
+                if (is_array($pagearrays)) {
+                    foreach ($pagearrays as $pagearray) {
+                        if (!isHiddenPage($pagearray['id'])) // skip hidden pages
                         $pages[] = $pagearray['id'];
+                    }
                 }
-            }
-            break;
-        case 'tagtopic':
-            if (!$this->taghelper)
+                break;
+            case 'tagtopic':
+                if (!$this->taghelper)
                 $this->taghelper = plugin_load('helper', 'tag');
-            if(!$this->taghelper) {
-                msg('You have to install the tag plugin to use this functionality!', -1);
-                return array();
-            }
-            $tag   = $page;
-            $sect  = '';
-            $pagearrays = $this->taghelper->getTopic('', null, $tag);
-            foreach ($pagearrays as $pagearray) {
-                $pages[] = $pagearray['id'];
-            }
-            break;
-        default:
-            $page = $this->_apply_macro($page, $parent_id);
-            // resolve shortcuts and clean ID
-            $page = (new PageResolver($parent_id))->resolveId($page);
-            if (auth_quickaclcheck($page) >= AUTH_READ)
+                if (!$this->taghelper) {
+                    msg('You have to install the tag plugin to use this functionality!', -1);
+                    return array();
+                }
+                $tag   = $page;
+                $sect  = '';
+                $pagearrays = $this->taghelper->getTopic('', null, $tag);
+                foreach ($pagearrays as $pagearray) {
+                    $pages[] = $pagearray['id'];
+                }
+                break;
+            default:
+                $page = $this->_apply_macro($page, $parent_id);
+                // resolve shortcuts and clean ID
+                $page = (new PageResolver($parent_id))->resolveId($page);
+                if (auth_quickaclcheck($page) >= AUTH_READ)
                 $pages[] = $page;
         }
 
         if (isset($flags['exclude']))
             $pages = array_filter($pages, function ($page) use ($flags) {
                 if (@preg_match($flags['exclude'], $page))
-                    return FALSE;
-                return TRUE;
+                    return false;
+                return true;
             });
 
         if (count($pages) > 1) {
@@ -769,7 +783,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                                 $key = '';
                             break;
                     }
-                    $key .= '_'.$page;
+                    $key .= '_' . $page;
                     $ordered_pages[$key] = $page;
                 }
                 if ($flags['rsort']) {
@@ -800,7 +814,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      * 0 if str1 is lesser than
      * str2, and 0 if they are equal.
      */
-    function _r_strnatcasecmp($a, $b) {
+    function _r_strnatcasecmp($a, $b)
+    {
         return strnatcasecmp($b, $a);
     }
 
@@ -808,7 +823,8 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      * This function generates the list of all included pages from a list of metadata
      * instructions.
      */
-    function _get_included_pages_from_meta_instructions($instructions) {
+    function _get_included_pages_from_meta_instructions($instructions)
+    {
         $pages = array();
         foreach ($instructions as $instruction) {
             $mode      = $instruction['mode'];
@@ -825,39 +841,45 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
      *  Get wiki language from "HTTP_ACCEPT_LANGUAGE"
      *  We allow the pattern e.g. "ja,en-US;q=0.7,en;q=0.3"
      */
-    function _get_language_of_wiki($id, $parent_id) {
-       global $conf;
-       $result = $conf['lang'];
-       if(strpos($id, '@BROWSER_LANG@') !== false){
-           $brlangp = "/([a-zA-Z]{1,8}(-[a-zA-Z]{1,8})*|\*)(;q=(0(.[0-9]{0,3})?|1(.0{0,3})?))?/";
-           if(preg_match_all(
-               $brlangp, $_SERVER["HTTP_ACCEPT_LANGUAGE"],
-               $matches, PREG_SET_ORDER
-           )){
-               $langs = array();
-               foreach($matches as $match){
-                   $langname = $match[1] == '*' ? $conf['lang'] : $match[1];
-                   $qvalue = $match[4] == '' ? 1.0 : $match[4];
-                   $langs[$langname] = $qvalue;
-               }
-               arsort($langs);
-               foreach($langs as $lang => $langq){
-                   $testpage = $this->_apply_macro(str_replace('@BROWSER_LANG@', $lang, $id), $parent_id);
-                   $testpage = (new PageResolver($parent_id))->resolveId($testpage);
-                   if (page_exists($testpage)) {
-                       $result = $lang;
-                       break;
-                   }
-               }
-           }
-       }
-       return cleanID($result);
+    function _get_language_of_wiki($id, $parent_id)
+    {
+        global $conf;
+        $result = $conf['lang'];
+        if (strpos($id, '@BROWSER_LANG@') !== false) {
+            $brlangp = "/([a-zA-Z]{1,8}(-[a-zA-Z]{1,8})*|\*)(;q=(0(.[0-9]{0,3})?|1(.0{0,3})?))?/";
+            if (
+                preg_match_all(
+                    $brlangp,
+                    $_SERVER["HTTP_ACCEPT_LANGUAGE"],
+                    $matches,
+                    PREG_SET_ORDER
+                )
+            ) {
+                $langs = array();
+                foreach ($matches as $match) {
+                    $langname = $match[1] == '*' ? $conf['lang'] : $match[1];
+                    $qvalue = $match[4] == '' ? 1.0 : $match[4];
+                    $langs[$langname] = $qvalue;
+                }
+                arsort($langs);
+                foreach ($langs as $lang => $langq) {
+                    $testpage = $this->_apply_macro(str_replace('@BROWSER_LANG@', $lang, $id), $parent_id);
+                    $testpage = (new PageResolver($parent_id))->resolveId($testpage);
+                    if (page_exists($testpage)) {
+                        $result = $lang;
+                        break;
+                    }
+                }
+            }
+        }
+        return cleanID($result);
     }
 
     /**
      * Makes user or date dependent includes possible
      */
-    function _apply_macro($id, $parent_id) {
+    function _apply_macro($id, $parent_id)
+    {
         global $USERINFO;
         /* @var Input $INPUT */
         global $INPUT;
@@ -865,7 +887,7 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
         // The following is basicaly copied from basicinfo() because
         // this function can be called from within pageinfo() in
         // p_get_metadata and thus we cannot rely on $INFO being set
-        if($INPUT->server->has('REMOTE_USER')) {
+        if ($INPUT->server->has('REMOTE_USER')) {
             $user  = $INPUT->server->str('REMOTE_USER');
         } else {
             // no registered user - use IP
@@ -887,34 +909,34 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
         }
 
         $time_stamp = time();
-        if(preg_match('/@DATE(\w+)@/',$id,$matches)) {
-            switch($matches[1]) {
-            case 'PMONTH':
-                $time_stamp = strtotime("-1 month");
-                break;
-            case 'NMONTH':
-                $time_stamp = strtotime("+1 month");
-                break;
-            case 'NWEEK':
-                $time_stamp = strtotime("+1 week");
-                break;
-            case 'PWEEK':
-                $time_stamp = strtotime("-1 week");
-                break;
-            case 'TOMORROW':
-                $time_stamp = strtotime("+1 day");
-                break;
-            case 'YESTERDAY':
-                $time_stamp = strtotime("-1 day");
-                break;
-            case 'NYEAR':
-                $time_stamp = strtotime("+1 year");
-                break;
-            case 'PYEAR':
-                $time_stamp = strtotime("-1 year");
-                break;
+        if (preg_match('/@DATE(\w+)@/', $id, $matches)) {
+            switch ($matches[1]) {
+                case 'PMONTH':
+                    $time_stamp = strtotime("-1 month");
+                    break;
+                case 'NMONTH':
+                    $time_stamp = strtotime("+1 month");
+                    break;
+                case 'NWEEK':
+                    $time_stamp = strtotime("+1 week");
+                    break;
+                case 'PWEEK':
+                    $time_stamp = strtotime("-1 week");
+                    break;
+                case 'TOMORROW':
+                    $time_stamp = strtotime("+1 day");
+                    break;
+                case 'YESTERDAY':
+                    $time_stamp = strtotime("-1 day");
+                    break;
+                case 'NYEAR':
+                    $time_stamp = strtotime("+1 year");
+                    break;
+                case 'PYEAR':
+                    $time_stamp = strtotime("-1 year");
+                    break;
             }
-            $id = preg_replace('/@DATE(\w+)@/','', $id);
+            $id = preg_replace('/@DATE(\w+)@/', '', $id);
         }
 
         $replace = array(
@@ -922,18 +944,18 @@ class helper_plugin_include extends DokuWiki_Plugin { // DokuWiki_Helper_Plugin
                 '@NAME@'  => cleanID($name),
                 '@GROUP@' => cleanID($group),
                 '@BROWSER_LANG@'  => $this->_get_language_of_wiki($id, $parent_id),
-                '@YEAR@'  => date('Y',$time_stamp),
-                '@MONTH@' => date('m',$time_stamp),
-                '@WEEK@' => date('W',$time_stamp),
-                '@DAY@'   => date('d',$time_stamp),
-                '@YEARPMONTH@' => date('Ym',strtotime("-1 month")),
-                '@PMONTH@' => date('m',strtotime("-1 month")),
-                '@NMONTH@' => date('m',strtotime("+1 month")),
-                '@YEARNMONTH@' => date('Ym',strtotime("+1 month")),
-                '@YEARPWEEK@' => date('YW',strtotime("-1 week")),
-                '@PWEEK@' => date('W',strtotime("-1 week")),
-                '@NWEEK@' => date('W',strtotime("+1 week")),
-                '@YEARNWEEK@' => date('YW',strtotime("+1 week")),
+                '@YEAR@'  => date('Y', $time_stamp),
+                '@MONTH@' => date('m', $time_stamp),
+                '@WEEK@' => date('W', $time_stamp),
+                '@DAY@'   => date('d', $time_stamp),
+                '@YEARPMONTH@' => date('Ym', strtotime("-1 month")),
+                '@PMONTH@' => date('m', strtotime("-1 month")),
+                '@NMONTH@' => date('m', strtotime("+1 month")),
+                '@YEARNMONTH@' => date('Ym', strtotime("+1 month")),
+                '@YEARPWEEK@' => date('YW', strtotime("-1 week")),
+                '@PWEEK@' => date('W', strtotime("-1 week")),
+                '@NWEEK@' => date('W', strtotime("+1 week")),
+                '@YEARNWEEK@' => date('YW', strtotime("+1 week")),
                 );
         return str_replace(array_keys($replace), array_values($replace), $id);
     }

--- a/helper.php
+++ b/helper.php
@@ -597,7 +597,7 @@ class helper_plugin_include extends Plugin
         return [
             0 => 'plugin',
             1 => [
-                'include_permalink',
+                'include_header',
                 [
                     $originalHeader[1][0],
                     $originalHeader[1][1],

--- a/syntax/closelastsecedit.php
+++ b/syntax/closelastsecedit.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Include plugin (close last section edit)
  *
@@ -6,24 +7,28 @@
  * @author  Michael Hamann <michael@content-space.de>
  */
 
-class syntax_plugin_include_closelastsecedit extends DokuWiki_Syntax_Plugin {
-
-    function getType() {
+class syntax_plugin_include_closelastsecedit extends DokuWiki_Syntax_Plugin
+{
+    function getType()
+    {
         return 'formatting';
     }
 
-    function getSort() {
+    function getSort()
+    {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler)
+    {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
     /**
      * Finishes the last open section edit
      */
-    function render($mode, Doku_Renderer $renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data)
+    {
         if ($mode == 'xhtml') {
             /** @var Doku_Renderer_xhtml $renderer */
             list($endpos) = $data;

--- a/syntax/closelastsecedit.php
+++ b/syntax/closelastsecedit.php
@@ -1,41 +1,45 @@
 <?php
 
+use dokuwiki\Extension\SyntaxPlugin;
+
 /**
  * Include plugin (close last section edit)
  *
  * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author  Michael Hamann <michael@content-space.de>
  */
-
-class syntax_plugin_include_closelastsecedit extends DokuWiki_Syntax_Plugin
+class syntax_plugin_include_closelastsecedit extends SyntaxPlugin
 {
-    function getType()
+    /** @inheritdoc */
+    public function getType()
     {
         return 'formatting';
     }
 
-    function getSort()
+    /** @inheritdoc */
+    public function getSort()
     {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler)
+    /** @inheritdoc */
+    public function handle($match, $state, $pos, Doku_Handler $handler)
     {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
     /**
      * Finishes the last open section edit
+     *
+     * @inheritdoc
      */
-    function render($mode, Doku_Renderer $renderer, $data)
+    public function render($mode, Doku_Renderer $renderer, $data)
     {
-        if ($mode == 'xhtml') {
-            /** @var Doku_Renderer_xhtml $renderer */
-            list($endpos) = $data;
-            $renderer->finishSectionEdit($endpos);
-            return true;
-        }
-        return false;
+        if ($mode != 'xhtml') return false;
+
+        /** @var Doku_Renderer_xhtml $renderer */
+        [$endpos] = $data;
+        $renderer->finishSectionEdit($endpos);
+        return true;
     }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/editbtn.php
+++ b/syntax/editbtn.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Include plugin (editbtn header component)
  *
@@ -6,17 +7,20 @@
  * @author  Michael Klier <chi@chimeric.de>
  */
 
-class syntax_plugin_include_editbtn extends DokuWiki_Syntax_Plugin {
-
-    function getType() {
+class syntax_plugin_include_editbtn extends DokuWiki_Syntax_Plugin
+{
+    function getType()
+    {
         return 'formatting';
     }
-    
-    function getSort() {
+
+    function getSort()
+    {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler)
+    {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
@@ -25,7 +29,8 @@ class syntax_plugin_include_editbtn extends DokuWiki_Syntax_Plugin {
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function render($mode, Doku_Renderer $renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data)
+    {
         list($title, $hid) = $data;
         if ($mode == 'xhtml') {
             if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions

--- a/syntax/editbtn.php
+++ b/syntax/editbtn.php
@@ -1,25 +1,29 @@
 <?php
 
+use dokuwiki\Extension\SyntaxPlugin;
+
 /**
  * Include plugin (editbtn header component)
  *
  * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author  Michael Klier <chi@chimeric.de>
  */
-
-class syntax_plugin_include_editbtn extends DokuWiki_Syntax_Plugin
+class syntax_plugin_include_editbtn extends SyntaxPlugin
 {
-    function getType()
+    /** @inheritdoc */
+    public function getType()
     {
         return 'formatting';
     }
 
-    function getSort()
+    /** @inheritdoc */
+    public function getSort()
     {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler)
+    /** @inheritdoc */
+    public function handle($match, $state, $pos, Doku_Handler $handler)
     {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
@@ -27,22 +31,15 @@ class syntax_plugin_include_editbtn extends DokuWiki_Syntax_Plugin
     /**
      * Renders an include edit button
      *
-     * @author Michael Klier <chi@chimeric.de>
+     * @inheritdoc
      */
-    function render($mode, Doku_Renderer $renderer, $data)
+    public function render($mode, Doku_Renderer $renderer, $data)
     {
-        list($title, $hid) = $data;
-        if ($mode == 'xhtml') {
-            if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
-                $renderer->startSectionEdit(0, array('target' => 'plugin_include_editbtn', 'name' => $title, 'hid' => $hid));
-            } else {
-                $renderer->startSectionEdit(0, 'plugin_include_editbtn', $title);
-            }
+        [$title, $hid] = $data;
+        if ($mode != 'xhtml') return false;
 
-            $renderer->finishSectionEdit();
-            return true;
-        }
-        return false;
+        $renderer->startSectionEdit(0, ['target' => 'plugin_include_editbtn', 'name' => $title, 'hid' => $hid]);
+        $renderer->finishSectionEdit();
+        return true;
     }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/editbtn.php
+++ b/syntax/editbtn.php
@@ -37,6 +37,7 @@ class syntax_plugin_include_editbtn extends SyntaxPlugin
     {
         [$title, $hid] = $data;
         if ($mode != 'xhtml') return false;
+        /** @var Doku_Renderer_xhtml $renderer */
 
         $renderer->startSectionEdit(0, ['target' => 'plugin_include_editbtn', 'name' => $title, 'hid' => $hid]);
         $renderer->finishSectionEdit();

--- a/syntax/footer.php
+++ b/syntax/footer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Include plugin (footer component)
  *
@@ -6,17 +7,20 @@
  * @author  Michael Klier <chi@chimeric.de>
  */
 
-class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin {
-
-    function getType() {
+class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin
+{
+    function getType()
+    {
         return 'formatting';
     }
 
-    function getSort() {
+    function getSort()
+    {
         return 300;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler)
+    {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
@@ -26,13 +30,14 @@ class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin {
      * Code heavily copied from the header renderer from inc/parser/xhtml.php, just
      * added an href parameter to the anchor tag linking to the wikilink.
      */
-    function render($mode, Doku_Renderer $renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data)
+    {
 
         list($page, $sect, $sect_title, $flags, $redirect_id, $footer_lvl) = $data;
 
         if ($mode == 'xhtml') {
             $renderer->doc .= $this->html_footer($page, $sect, $sect_title, $flags, $footer_lvl, $renderer);
-	        return true;
+            return true;
         }
         return false;
     }
@@ -42,10 +47,11 @@ class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin {
      * @param $renderer Doku_Renderer_xhtml The (xhtml) renderer
      * @return string The HTML code of the footer
      */
-    function html_footer($page, $sect, $sect_title, $flags, $footer_lvl, &$renderer) {
+    function html_footer($page, $sect, $sect_title, $flags, $footer_lvl, &$renderer)
+    {
         global $conf, $ID;
 
-        if(!$flags['footer']) return '';
+        if (!$flags['footer']) return '';
 
         $meta  = p_get_metadata($page);
         $exists = page_exists($page);
@@ -72,7 +78,7 @@ class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin {
         if ($flags['date'] && $exists) {
             $date = $meta['date']['created'];
             if ($date) {
-                $xhtml[] = '<abbr class="published" title="'.dformat($date, '%Y-%m-%dT%H:%M:%SZ').'">'
+                $xhtml[] = '<abbr class="published" title="' . dformat($date, '%Y-%m-%dT%H:%M:%SZ') . '">'
                        . dformat($date)
                        . '</abbr>';
             }
@@ -82,7 +88,7 @@ class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin {
         if ($flags['mdate'] && $exists) {
             $mdate = $meta['date']['modified'];
             if ($mdate) {
-                $xhtml[] = '<abbr class="published" title="'.dformat($mdate, '%Y-%m-%dT%H:%M:%SZ').'">'
+                $xhtml[] = '<abbr class="published" title="' . dformat($mdate, '%Y-%m-%dT%H:%M:%SZ') . '">'
                        . dformat($mdate)
                        . '</abbr>';
             }
@@ -117,7 +123,7 @@ class syntax_plugin_include_footer extends DokuWiki_Syntax_Plugin {
         // tags - let Tag Plugin do the work for us
         if (empty($sect) && $flags['tags'] && (!plugin_isdisabled('tag')) && ($tag = plugin_load('helper', 'tag'))) {
             $tags = $tag->td($page);
-            if($tags) {
+            if ($tags) {
                 $xhtml .= '<div class="tags"><span>' . DOKU_LF
                               . DOKU_TAB . $tags . DOKU_LF
                               . DOKU_TAB . '</span></div>' . DOKU_LF;

--- a/syntax/header.php
+++ b/syntax/header.php
@@ -1,5 +1,7 @@
 <?php
 
+use dokuwiki\Extension\SyntaxPlugin;
+
 /**
  * Include plugin (permalink header component)
  *
@@ -9,20 +11,22 @@
  * @author  Gina Haeussge <osd@foosel.net>
  * @author  Michael Klier <chi@chimeric.de>
  */
-
-class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin
+class syntax_plugin_include_header extends SyntaxPlugin
 {
-    function getType()
+    /** @inheritdoc */
+    public function getType()
     {
         return 'formatting';
     }
 
-    function getSort()
+    /** @inheritdoc */
+    public function getSort()
     {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler)
+    /** @inheritdoc */
+    public function handle($match, $state, $pos, Doku_Handler $handler)
     {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
@@ -32,47 +36,45 @@ class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin
      *
      * Code heavily copied from the header renderer from inc/parser/xhtml.php, just
      * added an href parameter to the anchor tag linking to the wikilink.
+     * @inheritdoc
      */
-    function render($mode, Doku_Renderer $renderer, $data)
+    public function render($mode, Doku_Renderer $renderer, $data)
     {
         global $conf;
 
-        list($headline, $lvl, $pos, $page, $sect, $flags) = $data;
+        [$headline, $lvl, $pos, $page, $sect, $flags] = $data;
 
-        if ($mode == 'xhtml') {
-            /** @var Doku_Renderer_xhtml $renderer */
-            $hid = $renderer->_headerToLink($headline, true);
-            $renderer->toc_additem($hid, $headline, $lvl);
-            $url = ($sect) ? wl($page) . '#' . $sect : wl($page);
-            $renderer->doc .= DOKU_LF . '<h' . $lvl;
-            $classes = array();
-            if ($flags['taglogos']) {
-                $tag = $this->_get_firsttag($page);
-                if ($tag) {
-                    $classes[] = 'include_firsttag__' . $tag;
-                }
-            }
-            // the include header instruction is always at the beginning of the first section edit inside the include
-            // wrap so there is no need to close a previous section edit.
-            if ($lvl <= $conf['maxseclevel']) {
-                if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
-                    $classes[] = $renderer->startSectionEdit($pos, array('target' => 'section', 'name' => $headline, 'hid' => $hid));
-                } else {
-                    $classes[] = $renderer->startSectionEdit($pos, 'section', $headline);
-                }
-            }
-            if ($classes) {
-                $renderer->doc .= ' class="' . implode(' ', $classes) . '"';
-            }
-            $headline = $renderer->_xmlEntities($headline);
-            $renderer->doc .= ' id="' . $hid . '"><a href="' . $url . '" title="' . $headline . '">';
-            $renderer->doc .= $headline;
-            $renderer->doc .= '</a></h' . $lvl . '>' . DOKU_LF;
-            return true;
-        } else {
+        if ($mode != 'xhtml') {
+            // just output a standard header for all non-xhtml modes
             $renderer->header($headline, $lvl, $pos);
+            return true;
         }
-        return false;
+
+        /** @var Doku_Renderer_xhtml $renderer */
+        $hid = $renderer->_headerToLink($headline, true);
+        $renderer->toc_additem($hid, $headline, $lvl);
+        $url = ($sect) ? wl($page) . '#' . $sect : wl($page);
+        $renderer->doc .= '<h' . $lvl;
+        $classes = [];
+        if ($flags['taglogos']) {
+            $tag = $this->getFirsttag($page);
+            if ($tag) {
+                $classes[] = 'include_firsttag__' . $tag;
+            }
+        }
+        // the include header instruction is always at the beginning of the first section edit inside the include
+        // wrap so there is no need to close a previous section edit.
+        if ($lvl <= $conf['maxseclevel']) {
+            $classes[] = $renderer->startSectionEdit($pos, ['target' => 'section', 'name' => $headline, 'hid' => $hid]);
+        }
+        if ($classes) {
+            $renderer->doc .= ' class="' . implode(' ', $classes) . '"';
+        }
+        $headline = $renderer->_xmlEntities($headline);
+        $renderer->doc .= ' id="' . $hid . '"><a href="' . $url . '" title="' . $headline . '">';
+        $renderer->doc .= $headline;
+        $renderer->doc .= '</a></h' . $lvl . '>';
+        return true;
     }
 
     /**
@@ -80,7 +82,7 @@ class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function _get_firsttag($page)
+    protected function getFirsttag($page)
     {
         if (plugin_isdisabled('tag') || (!plugin_load('helper', 'tag'))) {
             return false;
@@ -89,7 +91,7 @@ class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin
         if (is_array($subject)) {
             $tag = $subject[0];
         } else {
-            list($tag, $rest) = explode(' ', $subject, 2);
+            [$tag, $rest] = explode(' ', $subject, 2);
         }
         if ($tag) {
             return $tag;
@@ -98,4 +100,3 @@ class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin
         }
     }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/header.php
+++ b/syntax/header.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Include plugin (permalink header component)
  *
@@ -9,27 +10,31 @@
  * @author  Michael Klier <chi@chimeric.de>
  */
 
-class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin {
-
-    function getType() {
+class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin
+{
+    function getType()
+    {
         return 'formatting';
     }
-    
-    function getSort() {
+
+    function getSort()
+    {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler)
+    {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
     /**
      * Renders a permalink header.
-     * 
+     *
      * Code heavily copied from the header renderer from inc/parser/xhtml.php, just
      * added an href parameter to the anchor tag linking to the wikilink.
      */
-    function render($mode, Doku_Renderer $renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data)
+    {
         global $conf;
 
         list($headline, $lvl, $pos, $page, $sect, $flags) = $data;
@@ -39,11 +44,11 @@ class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin {
             $hid = $renderer->_headerToLink($headline, true);
             $renderer->toc_additem($hid, $headline, $lvl);
             $url = ($sect) ? wl($page) . '#' . $sect : wl($page);
-            $renderer->doc .= DOKU_LF.'<h' . $lvl;
+            $renderer->doc .= DOKU_LF . '<h' . $lvl;
             $classes = array();
-            if($flags['taglogos']) {
+            if ($flags['taglogos']) {
                 $tag = $this->_get_firsttag($page);
-                if($tag) {
+                if ($tag) {
                     $classes[] = 'include_firsttag__' . $tag;
                 }
             }
@@ -57,10 +62,10 @@ class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin {
                 }
             }
             if ($classes) {
-                $renderer->doc .= ' class="'. implode(' ', $classes) . '"';
+                $renderer->doc .= ' class="' . implode(' ', $classes) . '"';
             }
             $headline = $renderer->_xmlEntities($headline);
-            $renderer->doc .= ' id="'.$hid.'"><a href="' . $url . '" title="' . $headline . '">';
+            $renderer->doc .= ' id="' . $hid . '"><a href="' . $url . '" title="' . $headline . '">';
             $renderer->doc .= $headline;
             $renderer->doc .= '</a></h' . $lvl . '>' . DOKU_LF;
             return true;
@@ -75,8 +80,9 @@ class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin {
      *
      * @author Michael Klier <chi@chimeric.de>
      */
-    function _get_firsttag($page) {
-        if(plugin_isdisabled('tag') || (!plugin_load('helper', 'tag'))) {
+    function _get_firsttag($page)
+    {
+        if (plugin_isdisabled('tag') || (!plugin_load('helper', 'tag'))) {
             return false;
         }
         $subject = p_get_metadata($page, 'subject');
@@ -85,7 +91,7 @@ class syntax_plugin_include_header extends DokuWiki_Syntax_Plugin {
         } else {
             list($tag, $rest) = explode(' ', $subject, 2);
         }
-        if($tag) {
+        if ($tag) {
             return $tag;
         } else {
             return false;

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -1,5 +1,7 @@
 <?php
 
+use dokuwiki\Extension\SyntaxPlugin;
+
 /**
  * Include Plugin: displays a wiki page within another
  * Usage:
@@ -14,52 +16,31 @@
  * @author     Christopher Smith <chris@jalakai.co.uk>
  * @author     Gina Häußge, Michael Klier <dokuwiki@chimeric.de>
  */
-
-/**
- * All DokuWiki plugins to extend the parser/rendering mechanism
- * need to inherit from this class
- */
-class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin
+class syntax_plugin_include_include extends SyntaxPlugin
 {
     /** @var $helper helper_plugin_include */
-    var $helper = null;
+    public $helper;
 
-    /**
-     * Get syntax plugin type.
-     *
-     * @return string The plugin type.
-     */
-    function getType()
+    /** @inheritdoc */
+    public function getType()
     {
         return 'substition';
     }
 
-    /**
-     * Get sort order of syntax plugin.
-     *
-     * @return int The sort order.
-     */
-    function getSort()
+    /** @inheritdoc */
+    public function getSort()
     {
         return 303;
     }
 
-    /**
-     * Get paragraph type.
-     *
-     * @return string The paragraph type.
-     */
-    function getPType()
+    /** @inheritdoc */
+    public function getPType()
     {
         return 'block';
     }
 
-    /**
-     * Connect patterns/modes
-     *
-     * @param $mode mixed The current mode
-     */
-    function connectTo($mode)
+    /** @inheritdoc */
+    public function connectTo($mode)
     {
         $this->Lexer->addSpecialPattern("{{page>.+?}}", $mode, 'plugin_include_include');
         $this->Lexer->addSpecialPattern("{{section>.+?}}", $mode, 'plugin_include_include');
@@ -67,40 +48,28 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin
         $this->Lexer->addSpecialPattern("{{tagtopic>.+?}}", $mode, 'plugin_include_include');
     }
 
-    /**
-     * Handle syntax matches
-     *
-     * @param string       $match   The current match
-     * @param int          $state   The match state
-     * @param int          $pos     The position of the match
-     * @param Doku_Handler $handler The hanlder object
-     * @return array The instructions of the plugin
-     */
-    function handle($match, $state, $pos, Doku_Handler $handler)
+    /** @inheritdoc */
+    public function handle($match, $state, $pos, Doku_Handler $handler)
     {
 
         $match = substr($match, 2, -2); // strip markup
-        list($match, $flags) = array_pad(explode('&', $match, 2), 2, '');
+        [$match, $flags] = array_pad(explode('&', $match, 2), 2, '');
 
         // break the pattern up into its parts
-        list($mode, $page, $sect) = array_pad(preg_split('/>|#/u', $match, 3), 3, null);
+        [$mode, $page, $sect] = array_pad(preg_split('/>|#/u', $match, 3), 3, null);
         $check = false;
         if (isset($sect)) $sect = sectionID($sect, $check);
         $level = null;
-        return array($mode, $page, $sect, explode('&', $flags), $level, $pos);
+        return [$mode, $page, $sect, explode('&', $flags), $level, $pos];
     }
 
-    /**
-     * Renders the included page(s)
-     *
-     * @author Michael Hamann <michael@content-space.de>
-     */
-    function render($format, Doku_Renderer $renderer, $data)
+    /** @inheritdoc */
+    public function render($format, Doku_Renderer $renderer, $data)
     {
         global $ID;
 
         // static stack that records all ancestors of the child pages
-        static $page_stack = array();
+        static $page_stack = [];
 
         // when there is no id just assume the global $ID is the current id
         if (empty($page_stack)) $page_stack[] = $ID;
@@ -108,10 +77,11 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin
         $parent_id = $page_stack[count($page_stack) - 1];
         $root_id = $page_stack[0];
 
-        list($mode, $page, $sect, $flags, $level, $pos) = $data;
+        [$mode, $page, $sect, $flags, $level, $pos] = $data;
 
-        if (!$this->helper)
+        if (!$this->helper) {
             $this->helper = plugin_load('helper', 'include');
+        }
         $flags = $this->helper->get_flags($flags);
 
         $pages = $this->helper->_get_included_pages($mode, $page, $sect, $parent_id, $flags);
@@ -125,14 +95,24 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin
                 unset($renderer->meta['plugin_include']);
             }
 
-            $renderer->meta['plugin_include']['instructions'][] = compact('mode', 'page', 'sect', 'parent_id', 'flags');
-            if (!isset($renderer->meta['plugin_include']['pages']))
-               $renderer->meta['plugin_include']['pages'] = array(); // add an array for array_merge
-            $renderer->meta['plugin_include']['pages'] = array_merge($renderer->meta['plugin_include']['pages'], $pages);
+            $renderer->meta['plugin_include']['instructions'][] = [
+                'mode' => $mode,
+                'page' => $page,
+                'sect' => $sect,
+                'parent_id' => $parent_id,
+                'flags' => $flags
+            ];
+            if (!isset($renderer->meta['plugin_include']['pages'])) {
+                $renderer->meta['plugin_include']['pages'] = []; // add an array for array_merge
+            }
+            $renderer->meta['plugin_include']['pages'] = array_merge(
+                $renderer->meta['plugin_include']['pages'],
+                $pages
+            );
             $renderer->meta['plugin_include']['include_content'] = isset($_REQUEST['include_content']);
         }
 
-        $secids = array();
+        $secids = [];
         if ($format == 'xhtml' || $format == 'odt') {
             $secids = p_get_metadata($ID, 'plugin_include secids');
         }
@@ -143,14 +123,22 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin
             $exists = $page['exists'];
 
             if (in_array($id, $page_stack)) continue;
-            array_push($page_stack, $id);
+            $page_stack[] = $id;
 
             // add references for backlink
             if ($format == 'metadata') {
                 $renderer->meta['relation']['references'][$id] = $exists;
-                $renderer->meta['relation']['haspart'][$id]    = $exists;
-                if (!$sect && !$flags['firstsec'] && !$flags['linkonly'] && !isset($renderer->meta['plugin_include']['secids'][$id])) {
-                    $renderer->meta['plugin_include']['secids'][$id] = array('hid' => 'plugin_include__' . str_replace(':', '__', $id), 'pos' => $pos);
+                $renderer->meta['relation']['haspart'][$id] = $exists;
+                if (
+                    !$sect &&
+                    !$flags['firstsec'] &&
+                    !$flags['linkonly'] &&
+                    !isset($renderer->meta['plugin_include']['secids'][$id])
+                ) {
+                    $renderer->meta['plugin_include']['secids'][$id] = [
+                        'hid' => 'plugin_include__' . str_replace(':', '__', $id),
+                        'pos' => $pos
+                    ];
                 }
             }
 
@@ -160,7 +148,15 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin
                 unset($flags['include_secid']);
             }
 
-            $instructions = $this->helper->_get_instructions($id, $sect, $mode, $level, $flags, $root_id, $secids);
+            $instructions = $this->helper->_get_instructions(
+                $id,
+                $sect,
+                $mode,
+                $level,
+                $flags,
+                $root_id,
+                $secids
+            );
 
             if (!$flags['editbtn']) {
                 global $conf;
@@ -183,4 +179,3 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin
         return true;
     }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Include Plugin: displays a wiki page within another
  * Usage:
@@ -18,8 +19,8 @@
  * All DokuWiki plugins to extend the parser/rendering mechanism
  * need to inherit from this class
  */
-class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
-
+class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin
+{
     /** @var $helper helper_plugin_include */
     var $helper = null;
 
@@ -28,28 +29,38 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
      *
      * @return string The plugin type.
      */
-    function getType() { return 'substition'; }
+    function getType()
+    {
+        return 'substition';
+    }
 
     /**
      * Get sort order of syntax plugin.
      *
      * @return int The sort order.
      */
-    function getSort() { return 303; }
+    function getSort()
+    {
+        return 303;
+    }
 
     /**
      * Get paragraph type.
      *
      * @return string The paragraph type.
      */
-    function getPType() { return 'block'; }
+    function getPType()
+    {
+        return 'block';
+    }
 
     /**
      * Connect patterns/modes
      *
      * @param $mode mixed The current mode
      */
-    function connectTo($mode) {
+    function connectTo($mode)
+    {
         $this->Lexer->addSpecialPattern("{{page>.+?}}", $mode, 'plugin_include_include');
         $this->Lexer->addSpecialPattern("{{section>.+?}}", $mode, 'plugin_include_include');
         $this->Lexer->addSpecialPattern("{{namespace>.+?}}", $mode, 'plugin_include_include');
@@ -65,7 +76,8 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
      * @param Doku_Handler $handler The hanlder object
      * @return array The instructions of the plugin
      */
-    function handle($match, $state, $pos, Doku_Handler $handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler)
+    {
 
         $match = substr($match, 2, -2); // strip markup
         list($match, $flags) = array_pad(explode('&', $match, 2), 2, '');
@@ -74,7 +86,7 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
         list($mode, $page, $sect) = array_pad(preg_split('/>|#/u', $match, 3), 3, null);
         $check = false;
         if (isset($sect)) $sect = sectionID($sect, $check);
-        $level = NULL;
+        $level = null;
         return array($mode, $page, $sect, explode('&', $flags), $level, $pos);
     }
 
@@ -83,7 +95,8 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
      *
      * @author Michael Hamann <michael@content-space.de>
      */
-    function render($format, Doku_Renderer $renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data)
+    {
         global $ID;
 
         // static stack that records all ancestors of the child pages
@@ -92,7 +105,7 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
         // when there is no id just assume the global $ID is the current id
         if (empty($page_stack)) $page_stack[] = $ID;
 
-        $parent_id = $page_stack[count($page_stack)-1];
+        $parent_id = $page_stack[count($page_stack) - 1];
         $root_id = $page_stack[0];
 
         list($mode, $page, $sect, $flags, $level, $pos) = $data;
@@ -137,7 +150,7 @@ class syntax_plugin_include_include extends DokuWiki_Syntax_Plugin {
                 $renderer->meta['relation']['references'][$id] = $exists;
                 $renderer->meta['relation']['haspart'][$id]    = $exists;
                 if (!$sect && !$flags['firstsec'] && !$flags['linkonly'] && !isset($renderer->meta['plugin_include']['secids'][$id])) {
-                    $renderer->meta['plugin_include']['secids'][$id] = array('hid' => 'plugin_include__'.str_replace(':', '__', $id), 'pos' => $pos);
+                    $renderer->meta['plugin_include']['secids'][$id] = array('hid' => 'plugin_include__' . str_replace(':', '__', $id), 'pos' => $pos);
                 }
             }
 

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -82,7 +82,7 @@ class syntax_plugin_include_include extends SyntaxPlugin
         if (!$this->helper) {
             $this->helper = plugin_load('helper', 'include');
         }
-        $flags = $this->helper->get_flags($flags);
+        $flags = $this->helper->getFlags($flags);
 
         $pages = $this->helper->getIncludedPages($mode, $page, $sect, $parent_id, $flags);
 

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -84,7 +84,7 @@ class syntax_plugin_include_include extends SyntaxPlugin
         }
         $flags = $this->helper->get_flags($flags);
 
-        $pages = $this->helper->_get_included_pages($mode, $page, $sect, $parent_id, $flags);
+        $pages = $this->helper->getIncludedPages($mode, $page, $sect, $parent_id, $flags);
 
         if ($format == 'metadata') {
             /** @var Doku_Renderer_metadata $renderer */
@@ -148,7 +148,7 @@ class syntax_plugin_include_include extends SyntaxPlugin
                 unset($flags['include_secid']);
             }
 
-            $instructions = $this->helper->_get_instructions(
+            $instructions = $this->helper->getInstructions(
                 $id,
                 $sect,
                 $mode,

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -18,7 +18,7 @@ use dokuwiki\Extension\SyntaxPlugin;
  */
 class syntax_plugin_include_include extends SyntaxPlugin
 {
-    /** @var $helper helper_plugin_include */
+    /** @var helper_plugin_include $helper */
     public $helper;
 
     /** @inheritdoc */
@@ -127,6 +127,7 @@ class syntax_plugin_include_include extends SyntaxPlugin
 
             // add references for backlink
             if ($format == 'metadata') {
+                /** @var Doku_Renderer_metadata $renderer */
                 $renderer->meta['relation']['references'][$id] = $exists;
                 $renderer->meta['relation']['haspart'][$id] = $exists;
                 if (

--- a/syntax/locallink.php
+++ b/syntax/locallink.php
@@ -1,25 +1,29 @@
 <?php
 
+use dokuwiki\Extension\SyntaxPlugin;
+
 /**
  * Include plugin (locallink component)
  *
  * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author  Michael Hamann <michael@content-space.de>
  */
-
-class syntax_plugin_include_locallink extends DokuWiki_Syntax_Plugin
+class syntax_plugin_include_locallink extends SyntaxPlugin
 {
-    function getType()
+    /** @inheritdoc */
+    public function getType()
     {
         return 'formatting';
     }
 
-    function getSort()
+    /** @inheritdoc */
+    public function getSort()
     {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler)
+    /** @inheritdoc */
+    public function handle($match, $state, $pos, Doku_Handler $handler)
     {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
@@ -27,24 +31,22 @@ class syntax_plugin_include_locallink extends DokuWiki_Syntax_Plugin
     /**
      * Displays a local link to an included page
      *
-     * @author Michael Hamann <michael@content-space.de>
+     * @inheritdoc
      */
-    function render($mode, Doku_Renderer $renderer, $data)
+    public function render($mode, Doku_Renderer $renderer, $data)
     {
         global $ID;
-        if ($mode == 'xhtml') {
-            /** @var Doku_Renderer_xhtml $renderer */
-            list($hash, $name, $id) = $data;
-            // construct title in the same way it would be done for internal links
-            $default = $renderer->_simpleTitle($id);
-            $name    = $renderer->_getLinkTitle($name, $default, $isImage, $id);
-            $title   = $ID . ' ↵';
-            $renderer->doc .= '<a href="#' . $hash . '" title="' . $title . '" class="wikilink1">';
-            $renderer->doc .= $name;
-            $renderer->doc .= '</a>';
-            return true;
-        }
-        return false;
+        if ($mode != 'xhtml') return false;
+
+        /** @var Doku_Renderer_xhtml $renderer */
+        [$hash, $name, $id] = $data;
+        // construct title in the same way it would be done for internal links
+        $default = $renderer->_simpleTitle($id);
+        $name = $renderer->_getLinkTitle($name, $default, $isImage, $id);
+        $title = $ID . ' ↵';
+        $renderer->doc .= '<a href="#' . $hash . '" title="' . $title . '" class="wikilink1">';
+        $renderer->doc .= $name;
+        $renderer->doc .= '</a>';
+        return true;
     }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/locallink.php
+++ b/syntax/locallink.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Include plugin (locallink component)
  *
@@ -6,17 +7,20 @@
  * @author  Michael Hamann <michael@content-space.de>
  */
 
-class syntax_plugin_include_locallink extends DokuWiki_Syntax_Plugin {
-
-    function getType() {
+class syntax_plugin_include_locallink extends DokuWiki_Syntax_Plugin
+{
+    function getType()
+    {
         return 'formatting';
     }
 
-    function getSort() {
+    function getSort()
+    {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler)
+    {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
@@ -25,7 +29,8 @@ class syntax_plugin_include_locallink extends DokuWiki_Syntax_Plugin {
      *
      * @author Michael Hamann <michael@content-space.de>
      */
-    function render($mode, Doku_Renderer $renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data)
+    {
         global $ID;
         if ($mode == 'xhtml') {
             /** @var Doku_Renderer_xhtml $renderer */
@@ -33,8 +38,8 @@ class syntax_plugin_include_locallink extends DokuWiki_Syntax_Plugin {
             // construct title in the same way it would be done for internal links
             $default = $renderer->_simpleTitle($id);
             $name    = $renderer->_getLinkTitle($name, $default, $isImage, $id);
-            $title   = $ID.' ↵';
-            $renderer->doc .= '<a href="#'.$hash.'" title="'.$title.'" class="wikilink1">';
+            $title   = $ID . ' ↵';
+            $renderer->doc .= '<a href="#' . $hash . '" title="' . $title . '" class="wikilink1">';
             $renderer->doc .= $name;
             $renderer->doc .= '</a>';
             return true;

--- a/syntax/readmore.php
+++ b/syntax/readmore.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Include plugin (editbtn header component)
  *
@@ -6,25 +7,29 @@
  * @author  Michael Hamann <michael@content-space.de>
  */
 
-class syntax_plugin_include_readmore extends DokuWiki_Syntax_Plugin {
-
-    function getType() {
+class syntax_plugin_include_readmore extends DokuWiki_Syntax_Plugin
+{
+    function getType()
+    {
         return 'formatting';
     }
 
-    function getSort() {
+    function getSort()
+    {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler)
+    {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
-    function render($mode, Doku_Renderer $renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data)
+    {
         list($page) = $data;
 
         if ($mode == 'xhtml') {
-            $renderer->doc .= DOKU_LF.'<p class="include_readmore">'.DOKU_LF;
+            $renderer->doc .= DOKU_LF . '<p class="include_readmore">' . DOKU_LF;
         } else {
             $renderer->p_open();
         }
@@ -32,7 +37,7 @@ class syntax_plugin_include_readmore extends DokuWiki_Syntax_Plugin {
         $renderer->internallink($page, $this->getLang('readmore'));
 
         if ($mode == 'xhtml') {
-            $renderer->doc .= DOKU_LF.'</p>'.DOKU_LF;
+            $renderer->doc .= DOKU_LF . '</p>' . DOKU_LF;
         } else {
             $renderer->p_close();
         }

--- a/syntax/readmore.php
+++ b/syntax/readmore.php
@@ -1,35 +1,44 @@
 <?php
 
+use dokuwiki\Extension\SyntaxPlugin;
+
 /**
  * Include plugin (editbtn header component)
  *
  * @license GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author  Michael Hamann <michael@content-space.de>
  */
-
-class syntax_plugin_include_readmore extends DokuWiki_Syntax_Plugin
+class syntax_plugin_include_readmore extends SyntaxPlugin
 {
-    function getType()
+    /** @inheritdoc */
+    public function getType()
     {
         return 'formatting';
     }
 
-    function getSort()
+    /** @inheritdoc */
+    public function getSort()
     {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler)
+    /** @inheritdoc */
+    public function handle($match, $state, $pos, Doku_Handler $handler)
     {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
-    function render($mode, Doku_Renderer $renderer, $data)
+    /**
+     * Renders the readmore link for the included page.
+     *
+     * @inheritdoc
+     */
+    public function render($mode, Doku_Renderer $renderer, $data)
     {
-        list($page) = $data;
+        [$page] = $data;
 
         if ($mode == 'xhtml') {
-            $renderer->doc .= DOKU_LF . '<p class="include_readmore">' . DOKU_LF;
+            $renderer->doc .= '<p class="include_readmore">';
         } else {
             $renderer->p_open();
         }
@@ -37,7 +46,7 @@ class syntax_plugin_include_readmore extends DokuWiki_Syntax_Plugin
         $renderer->internallink($page, $this->getLang('readmore'));
 
         if ($mode == 'xhtml') {
-            $renderer->doc .= DOKU_LF . '</p>' . DOKU_LF;
+            $renderer->doc .= '</p>';
         } else {
             $renderer->p_close();
         }
@@ -45,4 +54,3 @@ class syntax_plugin_include_readmore extends DokuWiki_Syntax_Plugin
         return true;
     }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/sorttag.php
+++ b/syntax/sorttag.php
@@ -1,61 +1,48 @@
 <?php
 
+use dokuwiki\Extension\SyntaxPlugin;
+
 /**
  * Include plugin sort order tag, idea and parts of the code copied from the indexmenu plugin.
  *
  * @license     GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author      Samuele Tognini <samuele@netsons.org>
  * @author      Michael Hamann <michael@content-space.de>
- *
  */
-class syntax_plugin_include_sorttag extends DokuWiki_Syntax_Plugin
+class syntax_plugin_include_sorttag extends SyntaxPlugin
 {
-    /**
-     * What kind of syntax are we?
-     */
+    /** @inheritdoc */
     public function getType()
     {
         return 'substition';
     }
 
-    /**
-     * The paragraph type - block, we don't need paragraph tags
-     *
-     * @return string The paragraph type
-     */
+    /** @inheritdoc */
     public function getPType()
     {
         return 'block';
     }
 
-    /**
-     * Where to sort in?
-     */
+    /** @inheritdoc */
     public function getSort()
     {
         return 139;
     }
 
-    /**
-     * Connect pattern to lexer
-     */
+    /** @inheritdoc */
     public function connectTo($mode)
     {
         $this->Lexer->addSpecialPattern('{{include_n>.+?}}', $mode, 'plugin_include_sorttag');
     }
 
-    /**
-     * Handle the match
-     */
+    /** @inheritdoc */
     public function handle($match, $state, $pos, Doku_Handler $handler)
     {
         $match = substr($match, 12, -2);
-        return array($match);
+        return [$match];
     }
 
-    /**
-     * Render output
-     */
+    /** @inheritdoc */
     public function render($mode, Doku_Renderer $renderer, $data)
     {
         if ($mode === 'metadata') {

--- a/syntax/sorttag.php
+++ b/syntax/sorttag.php
@@ -8,12 +8,13 @@
  * @author      Michael Hamann <michael@content-space.de>
  *
  */
-class syntax_plugin_include_sorttag extends DokuWiki_Syntax_Plugin {
-
+class syntax_plugin_include_sorttag extends DokuWiki_Syntax_Plugin
+{
     /**
      * What kind of syntax are we?
      */
-    public function getType(){
+    public function getType()
+    {
         return 'substition';
     }
 
@@ -22,36 +23,41 @@ class syntax_plugin_include_sorttag extends DokuWiki_Syntax_Plugin {
      *
      * @return string The paragraph type
      */
-    public function getPType() {
+    public function getPType()
+    {
         return 'block';
     }
 
     /**
      * Where to sort in?
      */
-    public function getSort(){
+    public function getSort()
+    {
         return 139;
     }
 
     /**
      * Connect pattern to lexer
      */
-    public function connectTo($mode) {
-        $this->Lexer->addSpecialPattern('{{include_n>.+?}}',$mode,'plugin_include_sorttag');
+    public function connectTo($mode)
+    {
+        $this->Lexer->addSpecialPattern('{{include_n>.+?}}', $mode, 'plugin_include_sorttag');
     }
 
     /**
      * Handle the match
      */
-    public function handle($match, $state, $pos, Doku_Handler $handler){
-        $match = substr($match,12,-2);
+    public function handle($match, $state, $pos, Doku_Handler $handler)
+    {
+        $match = substr($match, 12, -2);
         return array($match);
     }
 
     /**
      * Render output
      */
-    public function render($mode, Doku_Renderer $renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data)
+    {
         if ($mode === 'metadata') {
             /** @var Doku_Renderer_metadata $renderer */
             $renderer->meta['include_n'] = $data[0];

--- a/syntax/wrap.php
+++ b/syntax/wrap.php
@@ -1,5 +1,7 @@
 <?php
 
+use dokuwiki\Extension\SyntaxPlugin;
+
 /**
  * Include plugin (wrapper component)
  *
@@ -7,20 +9,22 @@
  * @author  Michael Klier <chi@chimeric.de>
  * @author  Michael Hamann <michael@content-space.de>
  */
-
-class syntax_plugin_include_wrap extends DokuWiki_Syntax_Plugin
+class syntax_plugin_include_wrap extends SyntaxPlugin
 {
-    function getType()
+    /** @inheritdoc */
+    public function getType()
     {
         return 'formatting';
     }
 
-    function getSort()
+    /** @inheritdoc */
+    public function getSort()
     {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler)
+    /** @inheritdoc */
+    public function handle($match, $state, $pos, Doku_Handler $handler)
     {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
@@ -29,55 +33,47 @@ class syntax_plugin_include_wrap extends DokuWiki_Syntax_Plugin
      * Wraps the included page in a div and writes section edits for the action component
      * so it can detect where an included page starts/ends.
      *
-     * @author Michael Klier <chi@chimeric.de>
-     * @author Michael Hamann <michael@content-space.de>
+     * @inheritdoc
      */
-    function render($mode, Doku_Renderer $renderer, $data)
+    public function render($mode, Doku_Renderer $renderer, $data)
     {
-        if ($mode == 'xhtml') {
-            $state = array_shift($data);
-            switch ($state) {
-                case 'open':
-                    list($page, $redirect, $secid) = $data;
-                    if ($redirect) {
-                        if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
-                            $renderer->startSectionEdit(0, array('target' => 'plugin_include_start', 'name' => $page, 'hid' => ''));
-                        } else {
-                            $renderer->startSectionEdit(0, 'plugin_include_start', $page);
-                        }
-                    } else {
-                        if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
-                            $renderer->startSectionEdit(0, array('target' => 'plugin_include_start_noredirect', 'name' => $page, 'hid' => ''));
-                        } else {
-                            $renderer->startSectionEdit(0, 'plugin_include_start_noredirect', $page);
-                        }
-                    }
-                    $renderer->finishSectionEdit();
-                    // Start a new section with type != section so headers in the included page
-                    // won't print section edit buttons of the parent page
-                    if (defined('SEC_EDIT_PATTERN')) { // for DokuWiki Greebo and more recent versions
-                        $renderer->startSectionEdit(0, array('target' => 'plugin_include_end', 'name' => $page, 'hid' => ''));
-                    } else {
-                        $renderer->startSectionEdit(0, 'plugin_include_end', $page);
-                    }
-                    if ($secid === null) {
-                        $id = '';
-                    } else {
-                        $id = ' id="' . $secid . '"';
-                    }
-                    $renderer->doc .= '<div class="plugin_include_content plugin_include__' . $page . '"' . $id . '>' . DOKU_LF;
-                    if (is_a($renderer, 'renderer_plugin_dw2pdf')) {
-                        $renderer->doc .= '<a name="' . $secid . '" />';
-                    }
-                    break;
-                case 'close':
-                    $renderer->finishSectionEdit();
-                    $renderer->doc .= '</div>' . DOKU_LF;
-                    break;
-            }
-            return true;
+        if ($mode !== 'xhtml') return false;
+
+        $state = array_shift($data);
+        switch ($state) {
+            case 'open':
+                [$page, $redirect, $secid] = $data;
+                if ($redirect) {
+                    $renderer->startSectionEdit(
+                        0,
+                        ['target' => 'plugin_include_start', 'name' => $page, 'hid' => '']
+                    );
+                } else {
+                    $renderer->startSectionEdit(
+                        0,
+                        ['target' => 'plugin_include_start_noredirect', 'name' => $page, 'hid' => '']
+                    );
+                }
+                $renderer->finishSectionEdit();
+                // Start a new section with type != section so headers in the included page
+                // won't print section edit buttons of the parent page
+                $renderer->startSectionEdit(0, ['target' => 'plugin_include_end', 'name' => $page, 'hid' => '']);
+                if ($secid === null) {
+                    $id = '';
+                } else {
+                    $id = ' id="' . $secid . '"';
+                }
+                $renderer->doc .= '<div class="plugin_include_content plugin_include__' . $page . '"' . $id . '>';
+                if (is_a($renderer, 'renderer_plugin_dw2pdf')) {
+                    $renderer->doc .= '<a name="' . $secid . '" />';
+                }
+                break;
+            case 'close':
+                $renderer->finishSectionEdit();
+                $renderer->doc .= '</div>';
+                break;
         }
-        return false;
+
+        return true;
     }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/wrap.php
+++ b/syntax/wrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Include plugin (wrapper component)
  *
@@ -7,17 +8,20 @@
  * @author  Michael Hamann <michael@content-space.de>
  */
 
-class syntax_plugin_include_wrap extends DokuWiki_Syntax_Plugin {
-
-    function getType() {
+class syntax_plugin_include_wrap extends DokuWiki_Syntax_Plugin
+{
+    function getType()
+    {
         return 'formatting';
     }
 
-    function getSort() {
+    function getSort()
+    {
         return 50;
     }
 
-    function handle($match, $state, $pos, Doku_Handler $handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler)
+    {
         // this is a syntax plugin that doesn't offer any syntax, so there's nothing to handle by the parser
     }
 
@@ -28,10 +32,11 @@ class syntax_plugin_include_wrap extends DokuWiki_Syntax_Plugin {
      * @author Michael Klier <chi@chimeric.de>
      * @author Michael Hamann <michael@content-space.de>
      */
-    function render($mode, Doku_Renderer $renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data)
+    {
         if ($mode == 'xhtml') {
             $state = array_shift($data);
-            switch($state) {
+            switch ($state) {
                 case 'open':
                     list($page, $redirect, $secid) = $data;
                     if ($redirect) {
@@ -55,14 +60,14 @@ class syntax_plugin_include_wrap extends DokuWiki_Syntax_Plugin {
                     } else {
                         $renderer->startSectionEdit(0, 'plugin_include_end', $page);
                     }
-                    if ($secid === NULL) {
+                    if ($secid === null) {
                         $id = '';
                     } else {
-                        $id = ' id="'.$secid.'"';
+                        $id = ' id="' . $secid . '"';
                     }
-                    $renderer->doc .= '<div class="plugin_include_content plugin_include__' . $page .'"'.$id.'>' . DOKU_LF;
-                    if (is_a($renderer,'renderer_plugin_dw2pdf')) {
-                        $renderer->doc .= '<a name="'.$secid.'" />';
+                    $renderer->doc .= '<div class="plugin_include_content plugin_include__' . $page . '"' . $id . '>' . DOKU_LF;
+                    if (is_a($renderer, 'renderer_plugin_dw2pdf')) {
+                        $renderer->doc .= '<a name="' . $secid . '" />';
                     }
                     break;
                 case 'close':

--- a/syntax/wrap.php
+++ b/syntax/wrap.php
@@ -38,6 +38,7 @@ class syntax_plugin_include_wrap extends SyntaxPlugin
     public function render($mode, Doku_Renderer $renderer, $data)
     {
         if ($mode !== 'xhtml') return false;
+        /** @var Doku_Renderer_xhtml $renderer */
 
         $state = array_shift($data);
         switch ($state) {


### PR DESCRIPTION
This fixes most of the code style issues. PHP Code Sniffer and Rector have been applied file by file, so it's easier to review individual commits than everything at once.

This mostly addresses the obvious style issues but does not refactor the code (except for some smaller things I noticed while going through the code). Especially helper and action would need some more love (and doc blocks).

Note: for PSR-2 compatibility I had to rename a whole bunch of methods. Theoretically only the getFlags() method is supposed to be used from outside as it is the only one returned in getMethods, but I doubt that is the case. This branch should be checked at least with the blog plugin before merging.